### PR TITLE
Add display surface support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project( VULKAN_SAMPLES )
 
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 set_property( GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "" )
+set( SUPPORT_X ON CACHE BOOL "Compile with support for Xlib and XCB" )
+set( SUPPORT_DISPLAY_SURFACE OFF CACHE BOOL "Compile with support for VkDisplaySurface" )
+
 
 # The MAJOR number of the Vulkan version.
 # Used in naming vulkan-<major>.dll.
@@ -34,8 +37,21 @@ else()
         COMMAND python ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/vk-generate.py AllPlatforms dispatch-table-ops layer > ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/layers/vk_dispatch_table_helper.h
         )
 
-    set( XLIB_LIBRARIES X11 Xxf86vm Xrandr )
-    set( XCB_LIBRARIES xcb xcb-keysyms xcb-randr )
+	#Sanity check as we don't support compiling with more than one presentation/input path.
+	if( SUPPORT_X AND SUPPORT_DISPLAY_SURFACE)
+		message( FATAL_ERROR "SUPPORT_X and SUPPORT_DISPLAY_SURFACE cannot be enabled at the same time" )
+	endif()
+
+	if( SUPPORT_X )
+		add_definitions( -DSUPPORT_X )
+		set( XLIB_LIBRARIES X11 Xxf86vm Xrandr )
+		set( XCB_LIBRARIES xcb xcb-keysyms xcb-randr )
+	endif()
+endif()
+
+#This is outside the platform-specific blocks because in theory it is platform-neutral.
+if( SUPPORT_DISPLAY_SURFACE )
+	add_definitions( -DOS_NEUTRAL_DISPLAY_SURFACE )
 endif()
 
 add_subdirectory( external/include )

--- a/samples/apps/atw/CMakeLists.txt
+++ b/samples/apps/atw/CMakeLists.txt
@@ -51,5 +51,12 @@ else()
     add_executable( atw_vulkan atw_vulkan.c )
     target_compile_options( atw_vulkan PRIVATE -std=c99 -Wall -Wno-unused-function -Wno-unused-const-variable )
 	set_target_properties( atw_vulkan PROPERTIES FOLDER apps )
-    target_link_libraries( atw_vulkan m pthread dl ${XLIB_LIBRARIES} ${XCB_LIBRARIES} )
+    target_link_libraries( atw_vulkan m pthread dl )
+
+	#It's possible to build a non-X Linux version of the vulkan sample, so only conditionally link against xcb and xlib
+	if( SUPPORT_X )
+		target_link_libraries( atw_vulkan ${XLIB_LIBRARIES} )
+		target_link_libraries( atw_vulkan ${XCB_LIBRARIES} )
+	endif()
+
 endif()

--- a/samples/apps/atw/atw_vulkan.c
+++ b/samples/apps/atw/atw_vulkan.c
@@ -7127,7 +7127,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 		ANativeActivity_setWindowFlags( window->app->activity, AWINDOW_FLAG_FULLSCREEN | AWINDOW_FLAG_KEEP_SCREEN_ON, 0 );
 	}
 
-	ksGpuDevice_Create( &window->device, instance, GPU_DEVICE_CREATE_ALL, VK_NULL_HANDLE );
+	ksGpuDevice_Create( &window->device, instance, GPU_DEVICE_CREATE_ALL, queueInfo, VK_NULL_HANDLE );
 	ksGpuContext_Create( &window->context, &window->device, queueIndex );
 
 	return true;

--- a/samples/apps/atw/atw_vulkan.c
+++ b/samples/apps/atw/atw_vulkan.c
@@ -474,7 +474,7 @@ Platform headers / declarations
 
 	#include <time.h>							// for timespec
 	#include <sys/time.h>						// for gettimeofday()
-	#define __USE_UNIX98						// for pthread_mutexattr_settype
+	#define __USE_UNIX98 1						// for pthread_mutexattr_settype
 	#include <pthread.h>						// for pthread_create() etc.
 	#include <malloc.h>							// for memalign
 	#include <dlfcn.h>							// for dlopen


### PR DESCRIPTION
This stack of changes allows the atw_vulkan demo to run on PowerVR devices.

It's not the greatest rework in the world because building for DisplaySurface is not possible at the same time as, e.g. xcb. I'll do some more work in the future to allow runtime-selection of the presentation.

I've split the pull request into a few commits so if you start with the oldest commit and review them one-by-one it should make life easier.