### PR TITLE
Fixed compile error when USE_GLTF is set to 1

### DIFF
--- a/samples/apps/atw/atw_opengl.c
+++ b/samples/apps/atw/atw_opengl.c
@@ -14875,7 +14875,7 @@ static unsigned int StringHash( const char * string )
 		} \
 	} \
 	\
-	static Gltf##typeCapitalized##_t * ksGltf_Get##typeCapitalized##By##nameCapitalized( const ksGltfScene * scene, const char * name ) \
+	static ksGltf##typeCapitalized * ksGltf_Get##typeCapitalized##By##nameCapitalized( const ksGltfScene * scene, const char * name ) \
 	{ \
 		const unsigned int hash = StringHash( name ); \
 		for ( int i = scene->type##nameCapitalized##Hash[hash]; i >= 0; i = scene->type##nameCapitalized##Hash[HASH_TABLE_SIZE + i] ) \


### PR DESCRIPTION
This change was suggested by JP as a fix to a compile error I got when turning on USE_GLTF to test loading a gltf model.