### PR TITLE
Changed ATW samples to use nanoseconds instead of microseconds. Fixed previous JSON object/array member pointers going stale when new members are added. Fixed Vulkan-LoadAndValidation dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,25 +16,26 @@ set( MAJOR "1" )
 include_directories(
         "external/include"
         "../Vulkan-LoaderAndValidationLayers/include"
+        "../Vulkan-LoaderAndValidationLayers/build/generated/include"
         "$ENV{VK_SDK_PATH}/Include" )
 
 if( WIN32 )
     STRING( REGEX REPLACE "/" "\\\\" BASE_DIR "${CMAKE_SOURCE_DIR}" )
     add_custom_target( vk_dispatch_table_helper
-        COMMAND IF NOT exist ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\build\\layers (mkdir ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\build\\layers)
-        COMMAND python ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\scripts\\vk-generate.py AllPlatforms dispatch-table-ops layer > ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\build\\layers\\vk_dispatch_table_helper.h
+        COMMAND IF NOT exist ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\build\\generated\\include (mkdir ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\build\\generated\\include)
+        COMMAND python ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\scripts\\lvl_genvk.py -registry ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\scripts\\vk.xml vk_dispatch_table_helper.h -o ${BASE_DIR}\\..\\Vulkan-LoaderAndValidationLayers\\build\\generated\\include
         )
 elseif( APPLE )
     set( BASE_DIR "${CMAKE_SOURCE_DIR}" )
     add_custom_target( vk_dispatch_table_helper
-        COMMAND mkdir -p ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/layers
-        COMMAND python ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/vk-generate.py AllPlatforms dispatch-table-ops layer > ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/layers/vk_dispatch_table_helper.h
+        COMMAND mkdir -p ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/generated/include
+        COMMAND python ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/lvl_genvk.py -registry ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/vk.xml vk_dispatch_table_helper.h -o ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/generated/include
         )
 else()
     set( BASE_DIR "${CMAKE_SOURCE_DIR}" )
     add_custom_target( vk_dispatch_table_helper
-        COMMAND mkdir -p ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/layers
-        COMMAND python ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/vk-generate.py AllPlatforms dispatch-table-ops layer > ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/layers/vk_dispatch_table_helper.h
+        COMMAND mkdir -p ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/generated/include
+        COMMAND python ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/lvl_genvk.py -registry ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/scripts/vk.xml vk_dispatch_table_helper.h -o ${BASE_DIR}/../Vulkan-LoaderAndValidationLayers/build/generated/include
         )
 
 	#Sanity check as we don't support compiling with more than one presentation/input path.

--- a/build_android.bat
+++ b/build_android.bat
@@ -1,5 +1,5 @@
 mkdir ..\Vulkan-LoaderAndValidationLayers\build\generated\include
-python ..\Vulkan-LoaderAndValidationLayers\scripts\lvl_genvk.py -registry ..\Vulkan-LoaderAndValidationLayers\scripts\vk.xml vk_dispatch_table_helper.h -o ..\Vulkan-LoaderAndValidationLayers\build\generated\include
+python ..\Vulkan-LoaderAndValidationLayers\scripts\lvl_genvk.py -registry ..\Vulkan-LoaderAndValidationLayers\scripts\vk.xml vk_dispatch_table_helper.h -o ..\Vulkan-LoaderAndValidationLayers\build\generated\include\
 
 call %ANDROID_NDK_HOME%\ndk-build -C samples\apps\atw\projects\android\ndk\atw_cpu_dsp\ NDK_LIBS_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_cpu_dsp\libs NDK_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_cpu_dsp\obj
 call %ANDROID_NDK_HOME%\ndk-build -C samples\apps\atw\projects\android\ndk\atw_opengl\ NDK_LIBS_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_opengl\libs NDK_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_opengl\obj

--- a/build_android.bat
+++ b/build_android.bat
@@ -1,5 +1,5 @@
-mkdir ..\Vulkan-LoaderAndValidationLayers\build\layers
-python ..\Vulkan-LoaderAndValidationLayers\scripts\vk-generate.py AllPlatforms dispatch-table-ops layer > "..\Vulkan-LoaderAndValidationLayers\build\layers\vk_dispatch_table_helper.h"
+mkdir ..\Vulkan-LoaderAndValidationLayers\build\generated\include
+python ..\Vulkan-LoaderAndValidationLayers\scripts\lvl_genvk.py -registry ..\Vulkan-LoaderAndValidationLayers\scripts\vk.xml vk_dispatch_table_helper.h -o ..\Vulkan-LoaderAndValidationLayers\build\generated\include
 
 call %ANDROID_NDK_HOME%\ndk-build -C samples\apps\atw\projects\android\ndk\atw_cpu_dsp\ NDK_LIBS_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_cpu_dsp\libs NDK_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_cpu_dsp\obj
 call %ANDROID_NDK_HOME%\ndk-build -C samples\apps\atw\projects\android\ndk\atw_opengl\ NDK_LIBS_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_opengl\libs NDK_OUT=..\..\..\..\..\..\..\build\android\ndk\apps\atw_opengl\obj

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 mkdir -p ../Vulkan-LoaderAndValidationLayers/build/generated/include
-python ../Vulkan-LoaderAndValidationLayers/scripts/lvl_genvk.py -registry ../Vulkan-LoaderAndValidationLayers/scripts/vk.xml vk_dispatch_table_helper.h -o ../Vulkan-LoaderAndValidationLayers/build/generated/include
+python ../Vulkan-LoaderAndValidationLayers/scripts/lvl_genvk.py -registry ../Vulkan-LoaderAndValidationLayers/scripts/vk.xml vk_dispatch_table_helper.h -o ../Vulkan-LoaderAndValidationLayers/build/generated/include/
+
+ls -slaF .
+ls -slaF ../Vulkan-LoaderAndValidationLayers/build/generated/include/
 
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_cpu_dsp/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_cpu_dsp/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_cpu_dsp/obj
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_opengl/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_opengl/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_opengl/obj

--- a/build_android.sh
+++ b/build_android.sh
@@ -3,9 +3,6 @@
 mkdir -p ../Vulkan-LoaderAndValidationLayers/build/generated/include
 python ../Vulkan-LoaderAndValidationLayers/scripts/lvl_genvk.py -registry ../Vulkan-LoaderAndValidationLayers/scripts/vk.xml vk_dispatch_table_helper.h -o ../Vulkan-LoaderAndValidationLayers/build/generated/include/
 
-ls -slaF .
-ls -slaF ../Vulkan-LoaderAndValidationLayers/build/generated/include/
-
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_cpu_dsp/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_cpu_dsp/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_cpu_dsp/obj
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_opengl/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_opengl/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_opengl/obj
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_vulkan/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_vulkan/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_vulkan/obj

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-mkdir -p ../Vulkan-LoaderAndValidationLayers/build/layers
-python ../Vulkan-LoaderAndValidationLayers/scripts/vk-generate.py AllPlatforms dispatch-table-ops layer > "../Vulkan-LoaderAndValidationLayers/build/layers/vk_dispatch_table_helper.h"
+mkdir -p ../Vulkan-LoaderAndValidationLayers/build/generated/include
+python ../Vulkan-LoaderAndValidationLayers/scripts/lvl_genvk.py -registry ../Vulkan-LoaderAndValidationLayers/scripts/vk.xml vk_dispatch_table_helper.h -o ../Vulkan-LoaderAndValidationLayers/build/generated/include
 
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_cpu_dsp/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_cpu_dsp/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_cpu_dsp/obj
 ${ANDROID_NDK_HOME}/ndk-build -C samples/apps/atw/projects/android/ndk/atw_opengl/ NDK_LIBS_OUT=../../../../../../../build/android/ndk/apps/atw_opengl/libs NDK_OUT=../../../../../../../build/android/ndk/apps/atw_opengl/obj

--- a/external/include/utils/json.h
+++ b/external/include/utils/json.h
@@ -375,16 +375,16 @@ Text to DOM     2.6 GHz        2.6 GHz        2.1 GHz        2.1 GHz        2.1 
                 VS2015-up3     VS2015-up3     GCC 4.9        GCC 4.9        Clang 3.8      Clang 3.8
                 c++11          c++11          gnustl_static  gnustl_static  c++_static     c++_static
 ----------------------------------------------------------------------------------------------------------
-  Json_t        121.930 ms     107.169 ms      260.471 ms     229.713 ms     284.767 ms     244.413 ms
-  rapidjson     111.411 ms     112.965 ms      294.813 ms     217.756 ms     318.686 ms     267.120 ms
-  sajson         97.930 ms      67.170 ms      287.485 ms     167.319 ms     173.386 ms     182.552 ms
-  gason          63.300 ms      58.075 ms      116.311 ms     115.667 ms     195.282 ms     123.649 ms
-  ujson4c       118.903 ms     114.800 ms      417.591 ms     330.118 ms     364.956 ms     287.685 ms
-  cJSON         188.701 ms     169.897 ms      363.644 ms     315.248 ms     423.802 ms     319.888 ms
-  OVR::JSON     329.450 ms     294.698 ms      791.750 ms     883.271 ms     812.664 ms     879.435 ms
-  jsoncons      289.972 ms     230.264 ms      616.342 ms     582.109 ms     618.514 ms     451.056 ms
-  json11        507.506 ms     458.889 ms     2592.904 ms    2327.689 ms    2004.852 ms    1476.452 ms
-  nlohmann      470.255 ms     419.529 ms     1305.589 ms    1296.296 ms    1410.566 ms     988.472 ms
+  Json_t        123.704 ms     113.623 ms      260.471 ms     229.713 ms     284.767 ms     244.413 ms
+  rapidjson     113.475 ms     117.906 ms      294.813 ms     217.756 ms     318.686 ms     267.120 ms
+  sajson         99.068 ms      69.175 ms      287.485 ms     167.319 ms     173.386 ms     182.552 ms
+  gason          64.896 ms      57.836 ms      116.311 ms     115.667 ms     195.282 ms     123.649 ms
+  ujson4c       118.496 ms     106.542 ms      417.591 ms     330.118 ms     364.956 ms     287.685 ms
+  cJSON         189.076 ms     180.745 ms      363.644 ms     315.248 ms     423.802 ms     319.888 ms
+  OVR::JSON     334.811 ms     300.541 ms      791.750 ms     883.271 ms     812.664 ms     879.435 ms
+  jsoncons      276.632 ms     232.985 ms      616.342 ms     582.109 ms     618.514 ms     451.056 ms
+  json11        517.014 ms     467.236 ms     2592.904 ms    2327.689 ms    2004.852 ms    1476.452 ms
+  nlohmann      469.432 ms     422.636 ms     1305.589 ms    1296.296 ms    1410.566 ms     988.472 ms
 
 ----------------------------------------------------------------------------------------------------------
 Traverse DOM    2.6 GHz        2.6 GHz        2.1 GHz        2.1 GHz        2.1 GHz        2.1 GHz 
@@ -393,16 +393,16 @@ Traverse DOM    2.6 GHz        2.6 GHz        2.1 GHz        2.1 GHz        2.1 
                 VS2015-up3     VS2015-up3     GCC 4.9        GCC 4.9        Clang 3.8      Clang 3.8
                 c++11          c++11          gnustl_static  gnustl_static  c++_static     c++_static
 ----------------------------------------------------------------------------------------------------------
-  Json_t         22.131 ms      19.727 ms      106.081 ms      39.828 ms      84.220 ms      42.936 ms
-  rapidjson      40.618 ms      29.887 ms       82.376 ms      48.170 ms      75.268 ms      49.578 ms
-  sajson         26.316 ms      42.084 ms      153.721 ms     113.389 ms      95.203 ms      56.443 ms
-  gason          22.675 ms      22.880 ms      212.653 ms      99.502 ms     218.437 ms     103.013 ms
-  ujson4c        24.249 ms      30.401 ms      141.612 ms      82.157 ms      96.826 ms      87.144 ms
-  cJSON         271.376 ms     330.203 ms      522.007 ms     468.991 ms     600.157 ms     571.723 ms
-  OVR::JSON      55.858 ms      55.793 ms      334.563 ms     205.061 ms     332.576 ms     202.970 ms
-  jsoncons      150.714 ms     137.073 ms      542.477 ms     421.545 ms     963.076 ms     796.742 ms
-  json11        139.426 ms     123.035 ms      576.560 ms     449.121 ms     462.324 ms     292.826 ms
-  nlohmann      102.583 ms      95.926 ms      401.062 ms     501.726 ms     267.339 ms     169.525 ms
+  Json_t         15.963 ms      15.765 ms      106.081 ms      39.828 ms      84.220 ms      42.936 ms
+  rapidjson      39.516 ms      31.692 ms       82.376 ms      48.170 ms      75.268 ms      49.578 ms
+  sajson         39.083 ms      43.925 ms      153.721 ms     113.389 ms      95.203 ms      56.443 ms
+  gason          21.963 ms      23.685 ms      212.653 ms      99.502 ms     218.437 ms     103.013 ms
+  ujson4c        25.110 ms      25.750 ms      141.612 ms      82.157 ms      96.826 ms      87.144 ms
+  cJSON         302.371 ms     380.556 ms      522.007 ms     468.991 ms     600.157 ms     571.723 ms
+  OVR::JSON      55.423 ms      55.772 ms      334.563 ms     205.061 ms     332.576 ms     202.970 ms
+  jsoncons      154.659 ms     138.156 ms      542.477 ms     421.545 ms     963.076 ms     796.742 ms
+  json11        144.897 ms     126.033 ms      576.560 ms     449.121 ms     462.324 ms     292.826 ms
+  nlohmann      101.242 ms      99.691 ms      401.062 ms     501.726 ms     267.339 ms     169.525 ms
 
 ================================================================================================================================
 */
@@ -431,8 +431,8 @@ Traverse DOM    2.6 GHz        2.6 GHz        2.1 GHz        2.1 GHz        2.1 
 #define JSON_MAX( x, y )			( ( x >= y ) ? x : y )
 #define JSON_CLAMP( x, min, max )	( ( x >= min ) ? ( ( x <= max ) ? x : max ) : min )
 #define JSON_MAX_RECURSION			128
-#define JSON_MAP_GRANULARITY		4		// 64, 1024, 16384 etc. members
-#define JSON_BASE_ALLOC_PWR			3		// 8, 16, 32, 64, 128, 256, 512 etc. members
+#define JSON_MAP_GRANULARITY		4	// 128, 2048 etc. members
+#define JSON_BASE_ALLOC_PWR			4	// [16, 32, 64, 128], [256, 512, 1024, 2048] etc. members
 
 // JSON value type
 typedef enum

--- a/samples/apps/atw/atw_opengl.c
+++ b/samples/apps/atw/atw_opengl.c
@@ -578,7 +578,7 @@ Common defines
 
 #define GRAPHICS_API_OPENGL				1
 
-#define USE_GLTF						0
+#define USE_GLTF						1
 #define PROGRAM( name )					name##GLSL
 
 #define GLSL_EXTENSIONS					"#extension GL_EXT_shader_io_blocks : enable\n"
@@ -12062,6 +12062,7 @@ static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksNanoseco
 		return;
 	}
 
+	// FIXME: use double?
 	const float offset = time * ( MATH_PI / 1000.0f / 1000.0f / 1000.0f );
 	const float degrees = 10.0f;
 	const float degreesX = sinf( offset ) * degrees;

--- a/samples/apps/atw/atw_opengl.c
+++ b/samples/apps/atw/atw_opengl.c
@@ -383,6 +383,7 @@ Platform headers / declarations
 
 	#if defined( _MSC_VER )
 		#pragma warning( disable : 4204 )	// nonstandard extension used : non-constant aggregate initializer
+		#pragma warning( disable : 4221 )	// nonstandard extension used: 'layers': cannot be initialized using address of automatic variable 'layerProjection'
 		#pragma warning( disable : 4255 )	// '<name>' : no function prototype given: converting '()' to '(void)'
 		#pragma warning( disable : 4668 )	// '__cplusplus' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
 		#pragma warning( disable : 4710	)	// 'int printf(const char *const ,...)': function not inlined
@@ -578,7 +579,7 @@ Common defines
 
 #define GRAPHICS_API_OPENGL				1
 
-#define USE_GLTF						1
+#define USE_GLTF						0
 #define PROGRAM( name )					name##GLSL
 
 #define GLSL_EXTENSIONS					"#extension GL_EXT_shader_io_blocks : enable\n"

--- a/samples/apps/atw/atw_opengl.c
+++ b/samples/apps/atw/atw_opengl.c
@@ -412,7 +412,7 @@ Platform headers / declarations
 
 	#define __thread	__declspec( thread )
 
-#elif defined( OS_APPLE )
+#elif defined( OS_APPLE_MACOS )
 
 	// Apple is still at OpenGL 4.1
 	#define OPENGL_VERSION_MAJOR	4
@@ -444,6 +444,10 @@ Platform headers / declarations
 
 	#pragma clang diagnostic ignored "-Wunused-function"
 	#pragma clang diagnostic ignored "-Wunused-const-variable"
+
+#elif defined( OS_APPLE_IOS )
+
+// FIXME:
 
 #elif defined( OS_LINUX )
 
@@ -542,6 +546,7 @@ Common headers
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <math.h>
 #include <assert.h>
 #include <string.h>			// for memset
@@ -888,43 +893,43 @@ static const char * GetCPUVersion()
 	return "unknown";
 }
 
-typedef unsigned long long ksMicroseconds;
+typedef uint64_t ksNanoseconds;
 
-static ksMicroseconds GetTimeMicroseconds()
+static ksNanoseconds GetTimeNanoseconds()
 {
 #if defined( OS_WINDOWS )
-	static ksMicroseconds ticksPerSecond = 0;
-	static ksMicroseconds timeBase = 0;
+	static ksNanoseconds ticksPerSecond = 0;
+	static ksNanoseconds timeBase = 0;
 
 	if ( ticksPerSecond == 0 )
 	{
 		LARGE_INTEGER li;
 		QueryPerformanceFrequency( &li );
-		ticksPerSecond = (ksMicroseconds) li.QuadPart;
+		ticksPerSecond = (ksNanoseconds) li.QuadPart;
 		QueryPerformanceCounter( &li );
-		timeBase = (ksMicroseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
+		timeBase = (ksNanoseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
 	}
 
 	LARGE_INTEGER li;
 	QueryPerformanceCounter( &li );
-	ksMicroseconds counter = (ksMicroseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
-	return ( counter - timeBase ) * 1000ULL * 1000ULL / ticksPerSecond;
+	ksNanoseconds counter = (ksNanoseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
+	return ( counter - timeBase ) * 1000ULL * 1000ULL * 1000ULL / ticksPerSecond;
 #elif defined( OS_ANDROID )
 	struct timespec ts;
 	clock_gettime( CLOCK_MONOTONIC, &ts );
-	return (ksMicroseconds) ts.tv_sec * 1000ULL * 1000ULL + ts.tv_nsec / 1000ULL;
+	return (ksNanoseconds) ts.tv_sec * 1000ULL * 1000ULL * 1000ULL + ts.tv_nsec;
 #else
-	static ksMicroseconds timeBase = 0;
+	static ksNanoseconds timeBase = 0;
 
 	struct timeval tv;
 	gettimeofday( &tv, 0 );
 
 	if ( timeBase == 0 )
 	{
-		timeBase = (ksMicroseconds) tv.tv_sec * 1000ULL * 1000ULL;
+		timeBase = (ksNanoseconds) tv.tv_sec * 1000ULL * 1000ULL * 1000ULL;
 	}
 
-	return (ksMicroseconds) tv.tv_sec * 1000ULL * 1000ULL + tv.tv_usec - timeBase;
+	return (ksNanoseconds) tv.tv_sec * 1000ULL * 1000ULL * 1000ULL + tv.tv_usec * 1000ULL - timeBase;
 #endif
 }
 
@@ -1062,7 +1067,7 @@ ksSignal
 
 static void ksSignal_Create( ksSignal * signal, const bool autoReset );
 static void ksSignal_Destroy( ksSignal * signal );
-static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicroseconds );
+static bool ksSignal_Wait( ksSignal * signal, const ksNanoseconds timeOutNanoseconds );
 static void ksSignal_Raise( ksSignal * signal );
 static void ksSignal_Clear( ksSignal * signal );
 
@@ -1109,13 +1114,13 @@ static void ksSignal_Destroy( ksSignal * signal )
 
 // Waits for the object to enter the signalled state and returns true if this state is reached within the time-out period.
 // If 'autoReset' is true then the first thread that reaches the signalled state within the time-out period will clear the signalled state.
-// If 'timeOutMicroseconds' is SIGNAL_TIMEOUT_INFINITE then this will wait indefinitely until the signalled state is reached.
+// If 'timeOutNanoseconds' is SIGNAL_TIMEOUT_INFINITE then this will wait indefinitely until the signalled state is reached.
 // Returns true if the thread was released because the object entered the signalled state, returns false if the time-out is reached first.
-static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicroseconds )
+static bool ksSignal_Wait( ksSignal * signal, const ksNanoseconds timeOutNanoseconds )
 {
 #if defined( OS_WINDOWS )
-	DWORD result = WaitForSingleObject( signal->handle, ( timeOutMicroseconds == SIGNAL_TIMEOUT_INFINITE ) ? INFINITE : (DWORD)( timeOutMicroseconds / 1000 ) );
-	assert( result == WAIT_OBJECT_0 || ( timeOutMicroseconds != SIGNAL_TIMEOUT_INFINITE && result == WAIT_TIMEOUT ) );
+	DWORD result = WaitForSingleObject( signal->handle, ( timeOutNanoseconds == SIGNAL_TIMEOUT_INFINITE ) ? INFINITE : (DWORD)( timeOutNanoseconds / ( 1000 * 1000 ) ) );
+	assert( result == WAIT_OBJECT_0 || ( timeOutNanoseconds != SIGNAL_TIMEOUT_INFINITE && result == WAIT_TIMEOUT ) );
 	return ( result == WAIT_OBJECT_0 );
 #else
 	bool released = false;
@@ -1127,7 +1132,7 @@ static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicros
 	else
 	{
 		signal->waitCount++;
-		if ( timeOutMicroseconds == SIGNAL_TIMEOUT_INFINITE )
+		if ( timeOutNanoseconds == SIGNAL_TIMEOUT_INFINITE )
 		{
 			do
 			{
@@ -1135,13 +1140,13 @@ static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicros
 				// Must re-check condition because pthread_cond_wait may spuriously wake up.
 			} while ( signal->signaled == false );
 		}
-		else if ( timeOutMicroseconds > 0 )
+		else if ( timeOutNanoseconds > 0 )
 		{
 			struct timeval tp;
 			gettimeofday( &tp, NULL );
 			struct timespec ts;
-			ts.tv_sec = (time_t)( tp.tv_sec + timeOutMicroseconds / 1000000 );
-			ts.tv_nsec = (long)( ( tp.tv_usec + ( timeOutMicroseconds % 1000000 ) ) * 1000 );
+			ts.tv_sec = (time_t)( tp.tv_sec + timeOutNanoseconds / ( 1000 * 1000 * 1000 ) );
+			ts.tv_nsec = (long)( tp.tv_usec + ( timeOutNanoseconds % ( 1000 * 1000 * 1000 ) ) );
 			do
 			{
 				if ( pthread_cond_timedwait( &signal->cond, &signal->mutex, &ts ) == ETIMEDOUT )
@@ -1616,18 +1621,18 @@ ksFrameLog
 static void ksFrameLog_Open( const char * fileName, const int frameCount );
 static void ksFrameLog_Write( const char * fileName, const int lineNumber, const char * function );
 static void ksFrameLog_BeginFrame();
-static void ksFrameLog_EndFrame( const float cpuTimeMilliseconds, const float gpuTimeMilliseconds, const int gpuTimeFramesDelayed );
+static void ksFrameLog_EndFrame( const ksNanoseconds cpuTimeNanoseconds, const ksNanoseconds gpuTimeNanoseconds, const int gpuTimeFramesDelayed );
 
 ================================================================================================================================
 */
 
 typedef struct
 {
-	FILE *		fp;
-	float *		frameCpuTimes;
-	float *		frameGpuTimes;
-	int			frameCount;
-	int			frame;
+	FILE *			fp;
+	ksNanoseconds *	frameCpuTimes;
+	ksNanoseconds *	frameGpuTimes;
+	int				frameCount;
+	int				frame;
 } ksFrameLog;
 
 __thread ksFrameLog * threadFrameLog;
@@ -1657,8 +1662,8 @@ static void ksFrameLog_Open( const char * fileName, const int frameCount )
 		else
 		{
 			Print( "Opened frame log %s for %d frames.\n", fileName, frameCount );
-			l->frameCpuTimes = (float *) malloc( frameCount * sizeof( l->frameCpuTimes[0] ) );
-			l->frameGpuTimes = (float *) malloc( frameCount * sizeof( l->frameGpuTimes[0] ) );
+			l->frameCpuTimes = (ksNanoseconds *) malloc( frameCount * sizeof( l->frameCpuTimes[0] ) );
+			l->frameGpuTimes = (ksNanoseconds *) malloc( frameCount * sizeof( l->frameGpuTimes[0] ) );
 			memset( l->frameCpuTimes, 0, frameCount * sizeof( l->frameCpuTimes[0] ) );
 			memset( l->frameGpuTimes, 0, frameCount * sizeof( l->frameGpuTimes[0] ) );
 			l->frameCount = frameCount;
@@ -1693,21 +1698,21 @@ static void ksFrameLog_BeginFrame()
 	}
 }
 
-static void ksFrameLog_EndFrame( const float cpuTimeMilliseconds, const float gpuTimeMilliseconds, const int gpuTimeFramesDelayed )
+static void ksFrameLog_EndFrame( const ksNanoseconds cpuTimeNanoseconds, const ksNanoseconds gpuTimeNanoseconds, const int gpuTimeFramesDelayed )
 {
 	ksFrameLog * l = ksFrameLog_Get();
 	if ( l != NULL && l->fp != NULL )
 	{
 		if ( l->frame < l->frameCount )
 		{
-			l->frameCpuTimes[l->frame] = cpuTimeMilliseconds;
+			l->frameCpuTimes[l->frame] = cpuTimeNanoseconds;
 #if defined( _DEBUG )
 			fprintf( l->fp, "================ END FRAME %d ================\r\n", l->frame );
 #endif
 		}
 		if ( l->frame >= gpuTimeFramesDelayed && l->frame < l->frameCount + gpuTimeFramesDelayed )
 		{
-			l->frameGpuTimes[l->frame - gpuTimeFramesDelayed] = gpuTimeMilliseconds;
+			l->frameGpuTimes[l->frame - gpuTimeFramesDelayed] = gpuTimeNanoseconds;
 		}
 
 		l->frame++;
@@ -1716,7 +1721,7 @@ static void ksFrameLog_EndFrame( const float cpuTimeMilliseconds, const float gp
 		{
 			for ( int i = 0; i < l->frameCount; i++ )
 			{
-				fprintf( l->fp, "frame %d: CPU = %1.1f ms, GPU = %1.1f ms\r\n", i, l->frameCpuTimes[i], l->frameGpuTimes[i] );
+				fprintf( l->fp, "frame %d: CPU = %1.1f ms, GPU = %1.1f ms\r\n", i, l->frameCpuTimes[i] * 1e-6f, l->frameGpuTimes[i] * 1e-6f );
 			}
 
 			Print( "Closing frame log file (%d frames).\n", l->frameCount );
@@ -1769,10 +1774,10 @@ static void ksMatrix4x4f_CreateTranslation( ksMatrix4x4f * result, const float x
 static void ksMatrix4x4f_CreateRotation( ksMatrix4x4f * result, const float degreesX, const float degreesY, const float degreesZ );
 static void ksMatrix4x4f_CreateScale( ksMatrix4x4f * result, const float x, const float y, const float z );
 static void ksMatrix4x4f_CreateTranslationRotationScale( ksMatrix4x4f * result, const ksVector3f * scale, const ksQuatf * rotation, const ksVector3f * translation );
-static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float minX, const float maxX,
-											float const minY, const float maxY, const float nearZ, const float farZ );
-static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesX, const float fovDegreesY,
-											const float offsetX, const float offsetY, const float nearZ, const float farZ );
+static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float tanAngleLeft, const float tanAngleRight,
+											const float tanAngleUp, float const tanAngleDown, const float nearZ, const float farZ );
+static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesLeft, const float fovDegreesRight,
+											const float fovDegreeUp, const float fovDegreesDown, const float nearZ, const float farZ );
 static void ksMatrix4x4f_CreateFromQuaternion( ksMatrix3x4f * result, const ksQuatf * src );
 static void ksMatrix4x4f_CreateOffsetScaleForBounds( ksMatrix4x4f * result, const ksMatrix4x4f * matrix, const ksVector3f * mins, const ksVector3f * maxs );
 
@@ -1798,6 +1803,8 @@ static bool ksMatrix4x4f_CullBounds( const ksMatrix4x4f * mvp, const ksVector3f 
 
 ================================================================================================================================
 */
+
+#define DEFAULT_NEAR_Z		0.015625f		// exact floating point representation
 
 // 2D integer vector
 typedef struct
@@ -2260,17 +2267,17 @@ static void ksMatrix4x4f_CreateTranslationRotationScale( ksMatrix4x4f * result, 
 //		"Tightening the Precision of Perspective Rendering"
 //		Paul Upchurch, Mathieu Desbrun
 //		Journal of Graphics Tools, Volume 16, Issue 1, 2012
-static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float minX, const float maxX,
-											float const minY, const float maxY, const float nearZ, const float farZ )
+static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float tanAngleLeft, const float tanAngleRight,
+											const float tanAngleUp, float const tanAngleDown, const float nearZ, const float farZ )
 {
-	const float width = maxX - minX;
+	const float tanAngleWidth = tanAngleRight - tanAngleLeft;
 
 #if defined( GRAPHICS_API_VULKAN )
-	// Set to minY - maxY for a clip space with positive Y down (Vulkan).
-	const float height = minY - maxY;
+	// Set to tanAngleDown - tanAngleUp for a clip space with positive Y down (Vulkan).
+	const float tanAngleHeight = tanAngleDown - tanAngleUp;
 #else
-	// Set to maxY - minY for a clip space with positive Y up (OpenGL / D3D).
-	const float height = maxY - minY;
+	// Set to tanAngleUp - tanAngleDown for a clip space with positive Y up (OpenGL / D3D).
+	const float tanAngleHeight = tanAngleUp - tanAngleDown;
 #endif
 
 #if defined( GRAPHICS_API_OPENGL )
@@ -2284,14 +2291,14 @@ static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float mi
 	if ( farZ <= nearZ )
 	{
 		// place the far plane at infinity
-		result->m[0][0] = 2 * nearZ / width;
+		result->m[0][0] = 2 / tanAngleWidth;
 		result->m[1][0] = 0;
-		result->m[2][0] = ( maxX + minX ) / width;
+		result->m[2][0] = ( tanAngleRight + tanAngleLeft ) / tanAngleWidth;
 		result->m[3][0] = 0;
 
 		result->m[0][1] = 0;
-		result->m[1][1] = 2 * nearZ / height;
-		result->m[2][1] = ( maxY + minY ) / height;
+		result->m[1][1] = 2 / tanAngleHeight;
+		result->m[2][1] = ( tanAngleUp + tanAngleDown ) / tanAngleHeight;
 		result->m[3][1] = 0;
 
 		result->m[0][2] = 0;
@@ -2307,14 +2314,14 @@ static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float mi
 	else
 	{
 		// normal projection
-		result->m[0][0] = 2 * nearZ / width;
+		result->m[0][0] = 2 / tanAngleWidth;
 		result->m[1][0] = 0;
-		result->m[2][0] = ( maxX + minX ) / width;
+		result->m[2][0] = ( tanAngleRight + tanAngleLeft ) / tanAngleWidth;
 		result->m[3][0] = 0;
 
 		result->m[0][1] = 0;
-		result->m[1][1] = 2 * nearZ / height;
-		result->m[2][1] = ( maxY + minY ) / height;
+		result->m[1][1] = 2 / tanAngleHeight;
+		result->m[2][1] = ( tanAngleUp + tanAngleDown ) / tanAngleHeight;
 		result->m[3][1] = 0;
 
 		result->m[0][2] = 0;
@@ -2330,19 +2337,16 @@ static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float mi
 }
 
 // Creates a projection matrix based on the specified FOV.
-static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesX, const float fovDegreesY,
-												const float offsetX, const float offsetY, const float nearZ, const float farZ )
+static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesLeft, const float fovDegreesRight,
+												const float fovDegreesUp, const float fovDegreesDown, const float nearZ, const float farZ )
 {
-	const float halfWidth = nearZ * tanf( fovDegreesX * ( 0.5f * MATH_PI / 180.0f ) );
-	const float halfHeight = nearZ * tanf( fovDegreesY * ( 0.5f * MATH_PI / 180.0f ) );
+	const float tanLeft = - tanf( fovDegreesLeft * ( MATH_PI / 180.0f ) );
+	const float tanRight = tanf( fovDegreesRight * ( MATH_PI / 180.0f ) );
 
-	const float minX = offsetX - halfWidth;
-	const float maxX = offsetX + halfWidth;
+	const float tanDown = - tanf( fovDegreesDown * ( MATH_PI / 180.0f ) );
+	const float tanUp = tanf( fovDegreesUp * ( MATH_PI / 180.0f ) );
 
-	const float minY = offsetY - halfHeight;
-	const float maxY = offsetY + halfHeight;
-
-	ksMatrix4x4f_CreateProjection( result, minX, maxX, minY, maxY, nearZ, farZ );
+	ksMatrix4x4f_CreateProjection( result, tanLeft, tanRight, tanUp, tanDown, nearZ, farZ );
 }
 
 // Creates a matrix that transforms the -1 to 1 cube to cover the given 'mins' and 'maxs' transformed with the given 'matrix'.
@@ -4070,7 +4074,7 @@ static bool ksGpuContext_CreateForSurface( ksGpuContext * context, const ksGpuDe
 		EGL_DEPTH_SIZE,		bits.depthBits,
 		//EGL_STENCIL_SIZE,	0,
 		EGL_SAMPLE_BUFFERS,	( sampleCount > GPU_SAMPLE_COUNT_1 ),
-		EGL_SAMPLES,		sampleCount,
+		EGL_SAMPLES,		( sampleCount > GPU_SAMPLE_COUNT_1 ) ? sampleCount : 0,
 		EGL_NONE
 	};
 
@@ -4421,8 +4425,8 @@ static void ksGpuWindow_Exit( ksGpuWindow * window );
 static ksGpuWindowEvent ksGpuWindow_ProcessEvents( ksGpuWindow * window );
 static void ksGpuWindow_SwapInterval( ksGpuWindow * window, const int swapInterval );
 static void ksGpuWindow_SwapBuffers( ksGpuWindow * window );
-static ksMicroseconds ksGpuWindow_GetNextSwapTimeMicroseconds( ksGpuWindow * window );
-static ksMicroseconds ksGpuWindow_GetFrameTimeMicroseconds( ksGpuWindow * window );
+static ksNanoseconds ksGpuWindow_GetNextSwapTimeNanoseconds( ksGpuWindow * window );
+static ksNanoseconds ksGpuWindow_GetFrameTimeNanoseconds( ksGpuWindow * window );
 
 static bool ksGpuWindowInput_ConsumeKeyboardKey( ksGpuWindowInput * input, const ksKeyboardKey key );
 static bool ksGpuWindowInput_ConsumeMouseButton( ksGpuWindowInput * input, const ksMouseButton button );
@@ -4462,7 +4466,7 @@ typedef struct
 	bool					windowActive;
 	bool					windowExit;
 	ksGpuWindowInput		input;
-	ksMicroseconds			lastSwapTime;
+	ksNanoseconds			lastSwapTime;
 
 #if defined( OS_WINDOWS )
 	HINSTANCE				hInstance;
@@ -4685,7 +4689,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowActive = false;
 	window->windowExit = false;
 	window->windowActiveState = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	const LPCTSTR displayDevice = NULL;
 
@@ -4985,7 +4989,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 	window->uiView = myUIView;
 	window->uiWindow = myUIWindow;
 
@@ -5141,7 +5145,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	// Get a list of all available displays.
 	CGDirectDisplayID displays[32];
@@ -5782,7 +5786,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	const char * displayName = NULL;
 	window->xDisplay = XOpenDisplay( displayName );
@@ -6252,7 +6256,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	const char * displayName = NULL;
 	int screen_number = 0;
@@ -6722,7 +6726,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = true;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	window->app = global_app;
 	window->nativeWindow = NULL;
@@ -6884,34 +6888,34 @@ static void ksGpuWindow_SwapBuffers( ksGpuWindow * window )
 	EGL( eglSwapBuffers( window->context.display, window->context.mainSurface ) );
 #endif
 
-	ksMicroseconds newTimeMicroseconds = GetTimeMicroseconds();
+	ksNanoseconds newTimeNanoseconds = GetTimeNanoseconds();
 
 	// Even with smoothing, this is not particularly accurate.
-	const float frameTimeMicroseconds = 1000.0f * 1000.0f / window->windowRefreshRate;
-	const float deltaTimeMicroseconds = (float)newTimeMicroseconds - window->lastSwapTime - frameTimeMicroseconds;
-	if ( fabs( deltaTimeMicroseconds ) < frameTimeMicroseconds * 0.75f )
+	const float frameTimeNanoseconds = 1000.0f * 1000.0f * 1000.0f / window->windowRefreshRate;
+	const float deltaTimeNanoseconds = (float)newTimeNanoseconds - window->lastSwapTime - frameTimeNanoseconds;
+	if ( fabs( deltaTimeNanoseconds ) < frameTimeNanoseconds * 0.75f )
 	{
-		newTimeMicroseconds = (ksMicroseconds)( window->lastSwapTime + frameTimeMicroseconds + 0.025f * deltaTimeMicroseconds );
+		newTimeNanoseconds = (ksNanoseconds)( window->lastSwapTime + frameTimeNanoseconds + 0.025f * deltaTimeNanoseconds );
 	}
-	//const float smoothDeltaMicroseconds = (float)( newTimeMicroseconds - window->lastSwapTime );
-	//Print( "frame delta = %1.3f (error = %1.3f)\n", smoothDeltaMicroseconds * ( 1.0f / 1000.0f ),
-	//					( smoothDeltaMicroseconds - frameTimeMicroseconds ) * ( 1.0f / 1000.0f ) );
-	window->lastSwapTime = newTimeMicroseconds;
+	//const float smoothDeltaNanoseconds = (float)( newTimeNanoseconds - window->lastSwapTime );
+	//Print( "frame delta = %1.3f (error = %1.3f)\n", smoothDeltaNanoseconds * 1e-6f,
+	//					( smoothDeltaNanoseconds - frameTimeNanoseconds ) * 1e-6f );
+	window->lastSwapTime = newTimeNanoseconds;
 }
 
-static ksMicroseconds ksGpuWindow_GetNextSwapTimeMicroseconds( ksGpuWindow * window )
+static ksNanoseconds ksGpuWindow_GetNextSwapTimeNanoseconds( ksGpuWindow * window )
 {
-	const float frameTimeMicroseconds = 1000.0f * 1000.0f / window->windowRefreshRate;
-	return window->lastSwapTime + (ksMicroseconds)( frameTimeMicroseconds );
+	const float frameTimeNanoseconds = 1000.0f * 1000.0f * 1000.0f / window->windowRefreshRate;
+	return window->lastSwapTime + (ksNanoseconds)( frameTimeNanoseconds );
 }
 
-static ksMicroseconds ksGpuWindow_GetFrameTimeMicroseconds( ksGpuWindow * window )
+static ksNanoseconds ksGpuWindow_GetFrameTimeNanoseconds( ksGpuWindow * window )
 {
-	const float frameTimeMicroseconds = 1000.0f * 1000.0f / window->windowRefreshRate;
-	return (ksMicroseconds)( frameTimeMicroseconds );
+	const float frameTimeNanoseconds = 1000.0f * 1000.0f * 1000.0f / window->windowRefreshRate;
+	return (ksNanoseconds)( frameTimeNanoseconds );
 }
 
-static void ksGpuWindow_DelayBeforeSwap( ksGpuWindow * window, const ksMicroseconds delay )
+static void ksGpuWindow_DelayBeforeSwap( ksGpuWindow * window, const ksNanoseconds delay )
 {
 	UNUSED_PARM( window );
 	UNUSED_PARM( delay );
@@ -7049,7 +7053,7 @@ static bool ksGpuTexture_Create2DArray( ksGpuContext * context, ksGpuTexture * t
 static bool ksGpuTexture_CreateDefault( ksGpuContext * context, ksGpuTexture * texture, const ksGpuTextureDefault defaultType,
 									const int width, const int height, const int depth,
 									const int layerCount, const int faceCount, const bool mipmaps, const bool border );
-static bool ksGpuTexture_CreateFromSwapChain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index );
+static bool ksGpuTexture_CreateFromSwapchain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index );
 static bool ksGpuTexture_CreateFromFile( ksGpuContext * context, ksGpuTexture * texture, const char * fileName );
 static void ksGpuTexture_Destroy( ksGpuContext * context, ksGpuTexture * texture );
 
@@ -7846,7 +7850,7 @@ static bool ksGpuTexture_CreateDefault( ksGpuContext * context, ksGpuTexture * t
 	return success;
 }
 
-static bool ksGpuTexture_CreateFromSwapChain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index )
+static bool ksGpuTexture_CreateFromSwapchain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index )
 {
 	UNUSED_PARM( context );
 	UNUSED_PARM( index );
@@ -8726,7 +8730,7 @@ static bool ksGpuFramebuffer_CreateFromSwapchain( ksGpuWindow * window, ksGpuFra
 		assert( renderPass->colorFormat == window->colorFormat );
 		assert( renderPass->depthFormat == window->depthFormat );
 
-		ksGpuTexture_CreateFromSwapChain( &window->context, &framebuffer->colorTextures[bufferIndex], window, bufferIndex );
+		ksGpuTexture_CreateFromSwapchain( &window->context, &framebuffer->colorTextures[bufferIndex], window, bufferIndex );
 
 		assert( window->windowWidth == framebuffer->colorTextures[bufferIndex].width );
 		assert( window->windowHeight == framebuffer->colorTextures[bufferIndex].height );
@@ -10020,7 +10024,7 @@ GPU timer.
 
 A timer is used to measure the amount of time it takes to complete GPU commands.
 For optimal performance a timer should only be created at load time, not at runtime.
-To avoid synchronization, ksGpuTimer_GetMilliseconds() reports the time from GPU_TIMER_FRAMES_DELAYED frames ago.
+To avoid synchronization, ksGpuTimer_GetNanoseconds() reports the time from GPU_TIMER_FRAMES_DELAYED frames ago.
 Timer queries are allowed to overlap and can be nested.
 Timer queries that are issued inside a render pass may not produce accurate times on tiling GPUs.
 
@@ -10028,7 +10032,7 @@ ksGpuTimer
 
 static void ksGpuTimer_Create( ksGpuContext * context, ksGpuTimer * timer );
 static void ksGpuTimer_Destroy( ksGpuContext * context, ksGpuTimer * timer );
-static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer );
+static ksNanoseconds ksGpuTimer_GetNanoseconds( ksGpuTimer * timer );
 
 ================================================================================================================================
 */
@@ -10037,10 +10041,10 @@ static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer );
 
 typedef struct
 {
-	GLuint	beginQueries[GPU_TIMER_FRAMES_DELAYED];
-	GLuint	endQueries[GPU_TIMER_FRAMES_DELAYED];
-	int		queryIndex;
-	float	gpuTime;
+	GLuint			beginQueries[GPU_TIMER_FRAMES_DELAYED];
+	GLuint			endQueries[GPU_TIMER_FRAMES_DELAYED];
+	int				queryIndex;
+	ksNanoseconds	gpuTime;
 } ksGpuTimer;
 
 static void ksGpuTimer_Create( ksGpuContext * context, ksGpuTimer * timer )
@@ -10067,7 +10071,7 @@ static void ksGpuTimer_Destroy( ksGpuContext * context, ksGpuTimer * timer )
 	}
 }
 
-static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer )
+static ksNanoseconds ksGpuTimer_GetNanoseconds( ksGpuTimer * timer )
 {
 	if ( glExtensions.timer_query )
 	{
@@ -10075,7 +10079,7 @@ static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer )
 	}
 	else
 	{
-		return 0.0f;
+		return 0;
 	}
 }
 
@@ -10893,7 +10897,7 @@ static void ksGpuCommandBuffer_BeginTimer( ksGpuCommandBuffer * commandBuffer, k
 			GLuint64 endGpuTime = 0;
 			GL( glGetQueryObjectui64v( timer->endQueries[timer->queryIndex % GPU_TIMER_FRAMES_DELAYED], GL_QUERY_RESULT, &endGpuTime ) );
 
-			timer->gpuTime = ( endGpuTime - beginGpuTime ) / ( 1000.0f * 1000.0f );
+			timer->gpuTime = ( endGpuTime - beginGpuTime );
 		}
 
 		GL( glQueryCounter( timer->beginQueries[timer->queryIndex % GPU_TIMER_FRAMES_DELAYED], GL_TIMESTAMP ) );
@@ -11700,8 +11704,8 @@ static void ksTimeWarpBarGraphs_RenderGraphics( ksGpuCommandBuffer * commandBuff
 static void ksTimeWarpBarGraphs_UpdateCompute( ksGpuCommandBuffer * commandBuffer, ksTimeWarpBarGraphs * bargraphs );
 static void ksTimeWarpBarGraphs_RenderCompute( ksGpuCommandBuffer * commandBuffer, ksTimeWarpBarGraphs * bargraphs, ksGpuFramebuffer * framebuffer );
 
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsGraphics( ksTimeWarpBarGraphs * bargraphs );
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsCompute( ksTimeWarpBarGraphs * bargraphs );
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsGraphics( ksTimeWarpBarGraphs * bargraphs );
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsCompute( ksTimeWarpBarGraphs * bargraphs );
 
 ================================================================================================================================
 */
@@ -11743,7 +11747,7 @@ typedef struct
 {
 	ksBarGraphState	barGraphState;
 
-	ksBarGraph		eyeTexturesFrameRateGraph;
+	ksBarGraph		applicationFrameRateGraph;
 	ksBarGraph		timeWarpFrameRateGraph;
 	ksBarGraph		frameCpuTimeBarGraph;
 	ksBarGraph		frameGpuTimeBarGraph;
@@ -11765,7 +11769,7 @@ typedef struct
 
 enum
 {
-	PROFILE_TIME_EYE_TEXTURES,
+	PROFILE_TIME_APPLICATION,
 	PROFILE_TIME_TIME_WARP,
 	PROFILE_TIME_BAR_GRAPHS,
 	PROFILE_TIME_BLIT,
@@ -11793,7 +11797,7 @@ static void ksTimeWarpBarGraphs_Create( ksGpuContext * context, ksTimeWarpBarGra
 {
 	bargraphs->barGraphState = BAR_GRAPH_VISIBLE;
 
-	ksBarGraph_CreateVirtualRect( context, &bargraphs->eyeTexturesFrameRateGraph, renderPass, &eyeTextureFrameRateBarGraphRect, 64, 1, &colorDarkGrey );
+	ksBarGraph_CreateVirtualRect( context, &bargraphs->applicationFrameRateGraph, renderPass, &eyeTextureFrameRateBarGraphRect, 64, 1, &colorDarkGrey );
 	ksBarGraph_CreateVirtualRect( context, &bargraphs->timeWarpFrameRateGraph, renderPass, &timeWarpFrameRateBarGraphRect, 64, 1, &colorDarkGrey );
 	ksBarGraph_CreateVirtualRect( context, &bargraphs->frameCpuTimeBarGraph, renderPass, &frameCpuTimeBarGraphRect, 64, PROFILE_TIME_MAX, &colorDarkGrey );
 	ksBarGraph_CreateVirtualRect( context, &bargraphs->frameGpuTimeBarGraph, renderPass, &frameGpuTimeBarGraphRect, 64, PROFILE_TIME_MAX, &colorDarkGrey );
@@ -11823,7 +11827,7 @@ static void ksTimeWarpBarGraphs_Create( ksGpuContext * context, ksTimeWarpBarGra
 
 static void ksTimeWarpBarGraphs_Destroy( ksGpuContext * context, ksTimeWarpBarGraphs * bargraphs )
 {
-	ksBarGraph_Destroy( context, &bargraphs->eyeTexturesFrameRateGraph );
+	ksBarGraph_Destroy( context, &bargraphs->applicationFrameRateGraph );
 	ksBarGraph_Destroy( context, &bargraphs->timeWarpFrameRateGraph );
 	ksBarGraph_Destroy( context, &bargraphs->frameCpuTimeBarGraph );
 	ksBarGraph_Destroy( context, &bargraphs->frameGpuTimeBarGraph );
@@ -11847,7 +11851,7 @@ static void ksTimeWarpBarGraphs_UpdateGraphics( ksGpuCommandBuffer * commandBuff
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph );
+		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->applicationFrameRateGraph );
 		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->timeWarpFrameRateGraph );
 		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->frameCpuTimeBarGraph );
 		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->frameGpuTimeBarGraph );
@@ -11872,7 +11876,7 @@ static void ksTimeWarpBarGraphs_RenderGraphics( ksGpuCommandBuffer * commandBuff
 	{
 		ksGpuCommandBuffer_BeginTimer( commandBuffer, &bargraphs->barGraphTimer );
 
-		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph );
+		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->applicationFrameRateGraph );
 		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->timeWarpFrameRateGraph );
 		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->frameCpuTimeBarGraph );
 		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->frameGpuTimeBarGraph );
@@ -11897,7 +11901,7 @@ static void ksTimeWarpBarGraphs_UpdateCompute( ksGpuCommandBuffer * commandBuffe
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph );
+		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->applicationFrameRateGraph );
 		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->timeWarpFrameRateGraph );
 		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->frameCpuTimeBarGraph );
 		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->frameGpuTimeBarGraph );
@@ -11922,7 +11926,7 @@ static void ksTimeWarpBarGraphs_RenderCompute( ksGpuCommandBuffer * commandBuffe
 	{
 		ksGpuCommandBuffer_BeginTimer( commandBuffer, &bargraphs->barGraphTimer );
 
-		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph, framebuffer );
+		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->applicationFrameRateGraph, framebuffer );
 		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->timeWarpFrameRateGraph, framebuffer );
 		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->frameCpuTimeBarGraph, framebuffer );
 		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->frameGpuTimeBarGraph, framebuffer );
@@ -11943,22 +11947,22 @@ static void ksTimeWarpBarGraphs_RenderCompute( ksGpuCommandBuffer * commandBuffe
 	}
 }
 
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsGraphics( ksTimeWarpBarGraphs * bargraphs )
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsGraphics( ksTimeWarpBarGraphs * bargraphs )
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		return ksGpuTimer_GetMilliseconds( &bargraphs->barGraphTimer );
+		return ksGpuTimer_GetNanoseconds( &bargraphs->barGraphTimer );
 	}
-	return 0.0f;
+	return 0;
 }
 
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsCompute( ksTimeWarpBarGraphs * bargraphs )
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsCompute( ksTimeWarpBarGraphs * bargraphs )
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		return ksGpuTimer_GetMilliseconds( &bargraphs->barGraphTimer );
+		return ksGpuTimer_GetNanoseconds( &bargraphs->barGraphTimer );
 	}
-	return 0.0f;
+	return 0;
 }
 
 /*
@@ -12042,7 +12046,7 @@ static const ksBodyInfo * GetDefaultBodyInfo()
 
 static bool hmd_headRotationDisabled = false;
 
-static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksMicroseconds time )
+static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksNanoseconds time )
 {
 	if ( hmd_headRotationDisabled )
 	{
@@ -12050,7 +12054,7 @@ static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksMicrosec
 		return;
 	}
 
-	const float offset = time * ( MATH_PI / 1000.0f / 1000.0f );
+	const float offset = time * ( MATH_PI / 1000.0f / 1000.0f / 1000.0f );
 	const float degrees = 10.0f;
 	const float degreesX = sinf( offset ) * degrees;
 	const float degreesY = cosf( offset ) * degrees;
@@ -12219,11 +12223,11 @@ static void ksTimeWarpGraphics_Create( ksGpuContext * context, ksTimeWarpGraphic
 static void ksTimeWarpGraphics_Destroy( ksGpuContext * context, ksTimeWarpGraphics * graphics );
 static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpGraphics * graphics,
 									ksGpuFramebuffer * framebuffer, ksGpuRenderPass * renderPass,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] );
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] );
 
 ================================================================================================================================
 */
@@ -12481,13 +12485,13 @@ static void ksTimeWarpGraphics_Destroy( ksGpuContext * context, ksTimeWarpGraphi
 
 static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpGraphics * graphics,
 									ksGpuFramebuffer * framebuffer, ksGpuRenderPass * renderPass,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] )
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] )
 {
-	const ksMicroseconds t0 = GetTimeMicroseconds();
+	const ksNanoseconds t0 = GetTimeNanoseconds();
 
 	ksMatrix4x4f displayRefreshStartViewMatrix;
 	ksMatrix4x4f displayRefreshEndViewMatrix;
@@ -12530,7 +12534,7 @@ static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTim
 		ksGpuCommandBuffer_SubmitGraphicsCommand( commandBuffer, &command );
 	}
 
-	const ksMicroseconds t1 = GetTimeMicroseconds();
+	const ksNanoseconds t1 = GetTimeNanoseconds();
 
 	ksTimeWarpBarGraphs_RenderGraphics( commandBuffer, bargraphs );
 
@@ -12542,17 +12546,17 @@ static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTim
 
 	ksGpuCommandBuffer_SubmitPrimary( commandBuffer );
 
-	const ksMicroseconds t2 = GetTimeMicroseconds();
+	const ksNanoseconds t2 = GetTimeNanoseconds();
 
-	cpuTimes[PROFILE_TIME_TIME_WARP] = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = ( t2 - t1 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	cpuTimes[PROFILE_TIME_TIME_WARP] = t1 - t0;
+	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = t2 - t1;
+	cpuTimes[PROFILE_TIME_BLIT] = 0;
 
-	const float barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuMillisecondsGraphics( bargraphs );
+	const ksNanoseconds barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuNanosecondsGraphics( bargraphs );
 
-	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetMilliseconds( &graphics->timeWarpGpuTime ) - barGraphGpuTime;
+	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetNanoseconds( &graphics->timeWarpGpuTime ) - barGraphGpuTime;
 	gpuTimes[PROFILE_TIME_BAR_GRAPHS] = barGraphGpuTime;
-	gpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	gpuTimes[PROFILE_TIME_BLIT] = 0;
 
 #if GL_FINISH_SYNC == 1
 	GL( glFinish() );
@@ -12571,11 +12575,11 @@ static void ksTimeWarpCompute_Create( ksGpuContext * context, ksTimeWarpCompute 
 static void ksTimeWarpCompute_Destroy( ksGpuContext * context, ksTimeWarpCompute * compute );
 static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpCompute * compute,
 									ksGpuFramebuffer * framebuffer,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] );
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] );
 
 ================================================================================================================================
 */
@@ -12851,13 +12855,13 @@ static void ksTimeWarpCompute_Destroy( ksGpuContext * context, ksTimeWarpCompute
 
 static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpCompute * compute,
 									ksGpuFramebuffer * framebuffer,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] )
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] )
 {
-	const ksMicroseconds t0 = GetTimeMicroseconds();
+	const ksNanoseconds t0 = GetTimeNanoseconds();
 
 	ksMatrix4x4f displayRefreshStartViewMatrix;
 	ksMatrix4x4f displayRefreshEndViewMatrix;
@@ -12968,12 +12972,12 @@ static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTime
 		ksGpuCommandBuffer_SubmitComputeCommand( commandBuffer, &command );
 	}
 
-	const ksMicroseconds t1 = GetTimeMicroseconds();
+	const ksNanoseconds t1 = GetTimeNanoseconds();
 
 	ksTimeWarpBarGraphs_UpdateCompute( commandBuffer, bargraphs );
 	ksTimeWarpBarGraphs_RenderCompute( commandBuffer, bargraphs, &compute->framebuffer );
 
-	const ksMicroseconds t2 = GetTimeMicroseconds();
+	const ksNanoseconds t2 = GetTimeNanoseconds();
 
 	ksGpuCommandBuffer_Blit( commandBuffer, &compute->framebuffer, framebuffer );
 
@@ -12984,17 +12988,17 @@ static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTime
 
 	ksGpuCommandBuffer_SubmitPrimary( commandBuffer );
 
-	const ksMicroseconds t3 = GetTimeMicroseconds();
+	const ksNanoseconds t3 = GetTimeNanoseconds();
 
-	cpuTimes[PROFILE_TIME_TIME_WARP] = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = ( t2 - t1 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BLIT] = ( t3 - t2 ) * ( 1.0f / 1000.0f );
+	cpuTimes[PROFILE_TIME_TIME_WARP] = t1 - t0;
+	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = t2 - t1;
+	cpuTimes[PROFILE_TIME_BLIT] = t3 - t2;
 
-	const float barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuMillisecondsCompute( bargraphs );
+	const ksNanoseconds barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuNanosecondsCompute( bargraphs );
 
-	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetMilliseconds( &compute->timeWarpGpuTime ) - barGraphGpuTime;
+	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetNanoseconds( &compute->timeWarpGpuTime ) - barGraphGpuTime;
 	gpuTimes[PROFILE_TIME_BAR_GRAPHS] = barGraphGpuTime;
-	gpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	gpuTimes[PROFILE_TIME_BLIT] = 0;
 
 #if GL_FINISH_SYNC == 1
 	GL( glFinish() );
@@ -13026,11 +13030,11 @@ static void ksTimeWarpCompute_Destroy( ksGpuContext * context, ksTimeWarpCompute
 
 static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpCompute * compute,
 									ksGpuFramebuffer * framebuffer,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] )
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] )
 {
 	UNUSED_PARM( commandBuffer );
 	UNUSED_PARM( compute );
@@ -13075,11 +13079,11 @@ static void ksTimeWarp_SetDrawCallLevel( ksTimeWarp * timeWarp, const int level 
 static void ksTimeWarp_SetTriangleLevel( ksTimeWarp * timeWarp, const int level );
 static void ksTimeWarp_SetFragmentLevel( ksTimeWarp * timeWarp, const int level );
 
-static ksMicroseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex );
-static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksMicroseconds displayTime,
+static ksNanoseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex );
+static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksNanoseconds displayTime,
 									const ksMatrix4x4f * viewMatrix, const Matrix4x4_t * projectionMatrix,
 									ksGpuTexture * eyeTexture[NUM_EYES], ksGpuFence * eyeCompletionFence[NUM_EYES],
-									int eyeArrayLayer[NUM_EYES], float eyeTexturesCpuTime, float eyeTexturesGpuTime );
+									int eyeArrayLayer[NUM_EYES], ksNanoseconds eyeTexturesCpuTime, ksNanoseconds eyeTexturesGpuTime );
 static void ksTimeWarp_Render( ksTimeWarp * timeWarp );
 
 ================================================================================================================================
@@ -13098,28 +13102,28 @@ typedef struct
 {
 	int							index;
 	int							frameIndex;
-	ksMicroseconds				displayTime;
+	ksNanoseconds				displayTime;
 	ksMatrix4x4f				viewMatrix;
 	ksMatrix4x4f				projectionMatrix;
 	ksGpuTexture *				texture[NUM_EYES];
 	ksGpuFence *				completionFence[NUM_EYES];
 	int							arrayLayer[NUM_EYES];
-	float						cpuTime;
-	float						gpuTime;
+	ksNanoseconds				cpuTime;
+	ksNanoseconds				gpuTime;
 } ksEyeTextures;
 
 typedef struct
 {
 	long long					frameIndex;
-	ksMicroseconds				vsyncTime;
-	ksMicroseconds				frameTime;
+	ksNanoseconds				vsyncTime;
+	ksNanoseconds				frameTime;
 } ksFrameTiming;
 
 typedef struct
 {
 	ksGpuWindow *				window;
 	ksGpuTexture				defaultTexture;
-	ksMicroseconds				displayTime;
+	ksNanoseconds				displayTime;
 	ksMatrix4x4f				viewMatrix;
 	ksMatrix4x4f				projectionMatrix;
 	ksGpuTexture *				eyeTexture[NUM_EYES];
@@ -13136,11 +13140,11 @@ typedef struct
 	ksSignal					vsyncSignal;
 
 	float						refreshRate;
-	ksMicroseconds				frameCpuTime[AVERAGE_FRAME_RATE_FRAMES];
+	ksNanoseconds				frameCpuTime[AVERAGE_FRAME_RATE_FRAMES];
 	int							eyeTexturesFrames[AVERAGE_FRAME_RATE_FRAMES];
 	int							timeWarpFrames;
-	float						cpuTimes[PROFILE_TIME_MAX];
-	float						gpuTimes[PROFILE_TIME_MAX];
+	ksNanoseconds				cpuTimes[PROFILE_TIME_MAX];
+	ksNanoseconds				gpuTimes[PROFILE_TIME_MAX];
 
 	ksGpuRenderPass				renderPass;
 	ksGpuFramebuffer			framebuffer;
@@ -13166,15 +13170,15 @@ static void ksTimeWarp_Create( ksTimeWarp * timeWarp, ksGpuWindow * window )
 	timeWarp->newEyeTextures.index = 0;
 	timeWarp->newEyeTextures.displayTime = 0;
 	ksMatrix4x4f_CreateIdentity( &timeWarp->newEyeTextures.viewMatrix );
-	ksMatrix4x4f_CreateProjectionFov( &timeWarp->newEyeTextures.projectionMatrix, 80.0f, 80.0f, 0.0f, 0.0f, 0.1f, 0.0f );
+	ksMatrix4x4f_CreateProjectionFov( &timeWarp->newEyeTextures.projectionMatrix, 40.0f, 40.0f, 40.0f, 40.0f, 0.1f, 0.0f );
 	for ( int eye = 0; eye < NUM_EYES; eye++ )
 	{
 		timeWarp->newEyeTextures.texture[eye] = &timeWarp->defaultTexture;
 		timeWarp->newEyeTextures.completionFence[eye] = NULL;
 		timeWarp->newEyeTextures.arrayLayer[eye] = eye;
 	}
-	timeWarp->newEyeTextures.cpuTime = 0.0f;
-	timeWarp->newEyeTextures.gpuTime = 0.0f;
+	timeWarp->newEyeTextures.cpuTime = 0;
+	timeWarp->newEyeTextures.gpuTime = 0;
 
 	timeWarp->displayTime = 0;
 	timeWarp->viewMatrix = timeWarp->newEyeTextures.viewMatrix;
@@ -13342,7 +13346,7 @@ static void ksTimeWarp_SetFragmentLevel( ksTimeWarp * timeWarp, const int level 
 	}
 }
 
-static ksMicroseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex )
+static ksNanoseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex )
 {
 	ksMutex_Lock( &timeWarp->frameTimingMutex, true );
 	const ksFrameTiming frameTiming = timeWarp->frameTiming;
@@ -13350,18 +13354,19 @@ static ksMicroseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp,
 
 	// The time warp thread is currently released by SwapBuffers shortly after a V-Sync.
 	// Where possible, the time warp thread then waits until a short time before the next V-Sync,
-	// giving it just enough time to warp the latest eye textures onto the display. The time warp
-	// thread then tries to pick up the latest completed eye textures and warps them onto the
-	// display. The main thread is released right after the V-Sync and can start working on new
-	// eye textures that will be displayed effectively 2 display refresh cycles in the future.
+	// giving it just enough time to warp the last completed application frame onto the display.
+	// The time warp thread then tries to pick up the latest completed application frame and warps
+	// the frame onto the display. The application thread is released right after the V-Sync
+	// and can start working on a new frame that will be displayed effectively 2 display refresh
+	// cycles in the future.
 
 	return frameTiming.vsyncTime + ( frameIndex - frameTiming.frameIndex ) * frameTiming.frameTime;
 }
 
-static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksMicroseconds displayTime,
+static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksNanoseconds displayTime,
 									const ksMatrix4x4f * viewMatrix, const ksMatrix4x4f * projectionMatrix,
 									ksGpuTexture * eyeTexture[NUM_EYES], ksGpuFence * eyeCompletionFence[NUM_EYES],
-									int eyeArrayLayer[NUM_EYES], float eyeTexturesCpuTime, float eyeTexturesGpuTime )
+									int eyeArrayLayer[NUM_EYES], ksNanoseconds eyeTexturesCpuTime, ksNanoseconds eyeTexturesGpuTime )
 {
 	ksEyeTextures newEyeTextures;
 	newEyeTextures.index = timeWarp->eyeTexturesPresentIndex++;
@@ -13390,8 +13395,8 @@ static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex,
 
 	ksFrameTiming newFrameTiming;
 	newFrameTiming.frameIndex = frameIndex;
-	newFrameTiming.vsyncTime = ksGpuWindow_GetNextSwapTimeMicroseconds( timeWarp->window );
-	newFrameTiming.frameTime = ksGpuWindow_GetFrameTimeMicroseconds( timeWarp->window );
+	newFrameTiming.vsyncTime = ksGpuWindow_GetNextSwapTimeNanoseconds( timeWarp->window );
+	newFrameTiming.frameTime = ksGpuWindow_GetFrameTimeNanoseconds( timeWarp->window );
 
 	ksMutex_Lock( &timeWarp->frameTimingMutex, true );
 	timeWarp->frameTiming = newFrameTiming;
@@ -13400,8 +13405,8 @@ static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex,
 
 static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 {
-	const ksMicroseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeMicroseconds( timeWarp->window );
-	const ksMicroseconds frameTime = ksGpuWindow_GetFrameTimeMicroseconds( timeWarp->window );
+	const ksNanoseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeNanoseconds( timeWarp->window );
+	const ksNanoseconds frameTime = ksGpuWindow_GetFrameTimeNanoseconds( timeWarp->window );
 
 	// Wait until close to the next V-Sync but still far enough away to allow the time warp to complete rendering.
 	ksGpuWindow_DelayBeforeSwap( timeWarp->window, frameTime / 2 );
@@ -13434,8 +13439,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 				timeWarp->eyeTexture[eye] = newEyeTextures.texture[eye];
 				timeWarp->eyeArrayLayer[eye] = newEyeTextures.arrayLayer[eye];
 			}
-			timeWarp->cpuTimes[PROFILE_TIME_EYE_TEXTURES] = newEyeTextures.cpuTime;
-			timeWarp->gpuTimes[PROFILE_TIME_EYE_TEXTURES] = newEyeTextures.gpuTime;
+			timeWarp->cpuTimes[PROFILE_TIME_APPLICATION] = newEyeTextures.cpuTime;
+			timeWarp->gpuTimes[PROFILE_TIME_APPLICATION] = newEyeTextures.gpuTime;
 			timeWarp->eyeTexturesFrames[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES] = 1;
 			ksSignal_Clear( &timeWarp->vsyncSignal );
 			ksSignal_Raise( &timeWarp->newEyeTexturesConsumed );
@@ -13446,8 +13451,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 	float timeWarpFrameRate = timeWarp->refreshRate;
 	float eyeTexturesFrameRate = timeWarp->refreshRate;
 	{
-		ksMicroseconds lastTime = timeWarp->frameCpuTime[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES];
-		ksMicroseconds time = nextSwapTime;
+		ksNanoseconds lastTime = timeWarp->frameCpuTime[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES];
+		ksNanoseconds time = nextSwapTime;
 		timeWarp->frameCpuTime[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES] = time;
 		timeWarp->timeWarpFrames++;
 		if ( timeWarp->timeWarpFrames > AVERAGE_FRAME_RATE_FRAMES )
@@ -13459,28 +13464,28 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 				eyeTexturesFrames += timeWarp->eyeTexturesFrames[i];
 			}
 
-			timeWarpFrameRate = timeWarpFrames * 1000.0f * 1000.0f / ( time - lastTime );
-			eyeTexturesFrameRate = eyeTexturesFrames * 1000.0f * 1000.0f / ( time - lastTime );
+			timeWarpFrameRate = timeWarpFrames * 1e9f / ( time - lastTime );
+			eyeTexturesFrameRate = eyeTexturesFrames * 1e9f / ( time - lastTime );
 		}
 	}
 
 	// Update the bar graphs if not paused.
 	if ( timeWarp->bargraphs.barGraphState == BAR_GRAPH_VISIBLE )
 	{
-		const ksVector4f * eyeTexturesFrameRateColor = ( eyeTexturesFrameRate > timeWarp->refreshRate - 0.5f ) ? &colorPurple : &colorRed;
+		const ksVector4f * applicationFrameRateColor = ( eyeTexturesFrameRate > timeWarp->refreshRate - 0.5f ) ? &colorPurple : &colorRed;
 		const ksVector4f * timeWarpFrameRateColor = ( timeWarpFrameRate > timeWarp->refreshRate - 0.5f ) ? &colorGreen : &colorRed;
 
-		ksBarGraph_AddBar( &timeWarp->bargraphs.eyeTexturesFrameRateGraph, 0, eyeTexturesFrameRate / timeWarp->refreshRate, eyeTexturesFrameRateColor, true );
+		ksBarGraph_AddBar( &timeWarp->bargraphs.applicationFrameRateGraph, 0, eyeTexturesFrameRate / timeWarp->refreshRate, applicationFrameRateColor, true );
 		ksBarGraph_AddBar( &timeWarp->bargraphs.timeWarpFrameRateGraph, 0, timeWarpFrameRate / timeWarp->refreshRate, timeWarpFrameRateColor, true );
 
 		for ( int i = 0; i < 2; i++ )
 		{
-			const float * times = ( i == 0 ) ? timeWarp->cpuTimes : timeWarp->gpuTimes;
+			const ksNanoseconds * times = ( i == 0 ) ? timeWarp->cpuTimes : timeWarp->gpuTimes;
 			float barHeights[PROFILE_TIME_MAX];
 			float totalBarHeight = 0.0f;
 			for ( int p = 0; p < PROFILE_TIME_MAX; p++ )
 			{
-				barHeights[p] = times[p] * timeWarp->refreshRate * ( 1.0f / 1000.0f );
+				barHeights[p] = times[p] * timeWarp->refreshRate * 1e-9f;
 				totalBarHeight += barHeights[p];
 			}
 
@@ -13507,8 +13512,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 	ksFrameLog_BeginFrame();
 
 	//assert( timeWarp->displayTime == nextSwapTime );
-	const ksMicroseconds refreshStartTime = nextSwapTime;
-	const ksMicroseconds refreshEndTime = refreshStartTime /* + display refresh time for an incremental display refresh */;
+	const ksNanoseconds refreshStartTime = nextSwapTime;
+	const ksNanoseconds refreshEndTime = refreshStartTime /* + display refresh time for an incremental display refresh */;
 
 	if ( timeWarp->implementation == TIMEWARP_IMPLEMENTATION_GRAPHICS )
 	{
@@ -13530,11 +13535,11 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 	const int gpuTimeFramesDelayed = ( timeWarp->implementation == TIMEWARP_IMPLEMENTATION_GRAPHICS ) ? GPU_TIMER_FRAMES_DELAYED : 0;
 
 	ksFrameLog_EndFrame(	timeWarp->cpuTimes[PROFILE_TIME_TIME_WARP] +
-						timeWarp->cpuTimes[PROFILE_TIME_BAR_GRAPHS] +
-						timeWarp->cpuTimes[PROFILE_TIME_BLIT],
-						timeWarp->gpuTimes[PROFILE_TIME_TIME_WARP] +
-						timeWarp->gpuTimes[PROFILE_TIME_BAR_GRAPHS] +
-						timeWarp->gpuTimes[PROFILE_TIME_BLIT], gpuTimeFramesDelayed );
+							timeWarp->cpuTimes[PROFILE_TIME_BAR_GRAPHS] +
+							timeWarp->cpuTimes[PROFILE_TIME_BLIT],
+							timeWarp->gpuTimes[PROFILE_TIME_TIME_WARP] +
+							timeWarp->gpuTimes[PROFILE_TIME_BAR_GRAPHS] +
+							timeWarp->gpuTimes[PROFILE_TIME_BLIT], gpuTimeFramesDelayed );
 
 	ksGpuWindow_SwapBuffers( timeWarp->window );
 
@@ -13547,8 +13552,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 ksViewState
 
 static void ksViewState_Init( ksViewState * viewState, const float interpupillaryDistance );
-static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time );
-static void ksViewState_HandleHmd( ksViewState * viewState, const ksMicroseconds time );
+static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time );
+static void ksViewState_HandleHmd( ksViewState * viewState, const ksNanoseconds time );
 
 ================================================================================================================================
 */
@@ -13619,7 +13624,7 @@ static void ksViewState_Init( ksViewState * viewState, const float interpupillar
 	for ( int eye = 0; eye < NUM_EYES; eye++ )
 	{
 		ksMatrix4x4f_CreateIdentity( &viewState->viewMatrix[eye] );
-		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 90.0f, 60.0f, 0.0f, 0.0f, 0.01f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 45.0f, 45.0f, 30.0f, 30.0f, DEFAULT_NEAR_Z, 0.0f );
 
 		ksMatrix4x4f_Invert( &viewState->viewInverseMatrix[eye], &viewState->viewMatrix[eye] );
 		ksMatrix4x4f_Invert( &viewState->projectionInverseMatrix[eye], &viewState->projectionMatrix[eye] );
@@ -13628,7 +13633,7 @@ static void ksViewState_Init( ksViewState * viewState, const float interpupillar
 	ksViewState_DerivedData( viewState );
 }
 
-static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time )
+static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time )
 {
 	static const float TRANSLATION_UNITS_PER_TAP		= 0.005f;
 	static const float TRANSLATION_UNITS_DECAY			= 0.0025f;
@@ -13709,13 +13714,13 @@ static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput *
 		ksMatrix4x4f_CreateTranslation( &eyeOffsetMatrix, ( eye ? -0.5f : 0.5f ) * viewState->interpupillaryDistance, 0.0f, 0.0f );
 
 		ksMatrix4x4f_Multiply( &viewState->viewMatrix[eye], &eyeOffsetMatrix, &viewState->centerViewMatrix );
-		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 90.0f, 60.0f, 0.0f, 0.0f, 0.01f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 45.0f, 45.0f, 30.0f, 30.0f, DEFAULT_NEAR_Z, 0.0f );
 	}
 
 	ksViewState_DerivedData( viewState );
 }
 
-static void ksViewState_HandleHmd( ksViewState * viewState, const ksMicroseconds time )
+static void ksViewState_HandleHmd( ksViewState * viewState, const ksNanoseconds time )
 {
 	GetHmdViewMatrixForTime( &viewState->hmdViewMatrix, time );
 
@@ -13727,7 +13732,7 @@ static void ksViewState_HandleHmd( ksViewState * viewState, const ksMicroseconds
 		ksMatrix4x4f_CreateTranslation( &eyeOffsetMatrix, ( eye ? -0.5f : 0.5f ) * viewState->interpupillaryDistance, 0.0f, 0.0f );
 
 		ksMatrix4x4f_Multiply( &viewState->viewMatrix[eye], &eyeOffsetMatrix, &viewState->centerViewMatrix );
-		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 90.0f, 72.0f, 0.0f, 0.0f, 0.01f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 45.0f, 45.0f, 36.0f, 36.0f, DEFAULT_NEAR_Z, 0.0f );
 	}
 
 	ksViewState_DerivedData( viewState );
@@ -13886,7 +13891,7 @@ ksPerfScene
 
 static void ksPerfScene_Create( ksGpuContext * context, ksPerfScene * scene, ksSceneSettings * settings, ksGpuRenderPass * renderPass );
 static void ksPerfScene_Destroy( ksGpuContext * context, ksPerfScene * scene );
-static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksMicroseconds time );
+static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksNanoseconds time );
 static void ksPerfScene_UpdateBuffers( ksGpuCommandBuffer * commandBuffer, ksPerfScene * scene, ksViewState * viewState, const int eye );
 static void ksPerfScene_Render( ksGpuCommandBuffer * commandBuffer, ksPerfScene * scene );
 
@@ -14349,7 +14354,7 @@ static void ksPerfScene_Destroy( ksGpuContext * context, ksPerfScene * scene )
 	scene->modelMatrix = NULL;
 }
 
-static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksMicroseconds time )
+static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksNanoseconds time )
 {
 	// Must recreate the scene if multi-view is enabled/disabled.
 	assert( scene->settings.useMultiView == scene->newSettings->useMultiView );
@@ -14359,7 +14364,7 @@ static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, 
 
 	if ( !scene->settings.simulationPaused )
 	{
-		const float offset = time * ( MATH_PI / 1000.0f / 1000.0f );
+		const float offset = time * ( MATH_PI / 1000.0f / 1000.0f / 1000.0f );
 		scene->bigRotationX = 20.0f * offset;
 		scene->bigRotationY = 10.0f * offset;
 		scene->smallRotationX = -60.0f * offset;
@@ -14437,7 +14442,7 @@ ksGltfScene
 
 static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * scene, const char * fileName, ksGpuRenderPass * renderPass );
 static void ksGltfScene_Destroy( ksGpuContext * context, ksGltfScene * scene );
-static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time );
+static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time );
 static void ksGltfScene_UpdateBuffers( ksGpuCommandBuffer * commandBuffer, const ksGltfScene * scene, const ksViewState * viewState, const int eye );
 static void ksGltfScene_Render( ksGpuCommandBuffer * commandBuffer, const ksGltfScene * scene, const ksViewState * viewState, const int eye );
 
@@ -14875,7 +14880,7 @@ static unsigned int StringHash( const char * string )
 		} \
 	} \
 	\
-	static Gltf##typeCapitalized##_t * ksGltf_Get##typeCapitalized##By##nameCapitalized( const ksGltfScene * scene, const char * name ) \
+	static ksGltf##typeCapitalized * ksGltf_Get##typeCapitalized##By##nameCapitalized( const ksGltfScene * scene, const char * name ) \
 	{ \
 		const unsigned int hash = StringHash( name ); \
 		for ( int i = scene->type##nameCapitalized##Hash[hash]; i >= 0; i = scene->type##nameCapitalized##Hash[HASH_TABLE_SIZE + i] ) \
@@ -15209,7 +15214,7 @@ static void ksGltf_SortNodes( ksGltfNode * nodes, const int nodeCount )
 
 static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * scene, const char * fileName, ksGpuRenderPass * renderPass )
 {
-	const ksMicroseconds t0 = GetTimeMicroseconds();
+	const ksNanoseconds t0 = GetTimeNanoseconds();
 
 	memset( scene, 0, sizeof( ksGltfScene ) );
 
@@ -15231,7 +15236,7 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 		// glTF buffers
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * buffers = Json_GetMemberByName( rootNode, "buffers" );
 			scene->bufferCount = Json_GetMemberCount( buffers );
@@ -15249,15 +15254,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateBufferNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load buffers\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load buffers\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF bufferViews
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * bufferViews = Json_GetMemberByName( rootNode, "bufferViews" );
 			scene->bufferViewCount = Json_GetMemberCount( bufferViews );
@@ -15277,15 +15282,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateBufferViewNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load buffer views\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load buffer views\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF accessors
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * accessors = Json_GetMemberByName( rootNode, "accessors" );
 			scene->accessorCount = Json_GetMemberCount( accessors );
@@ -15338,15 +15343,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateAccessorNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load accessors\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load accessors\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF images
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * images = Json_GetMemberByName( rootNode, "images" );
 			scene->imageCount = Json_GetMemberCount( images );
@@ -15361,15 +15366,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateImageNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load images\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load images\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF samplers
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * samplers = Json_GetMemberByName( rootNode, "samplers" );
 			scene->samplerCount = Json_GetMemberCount( samplers );
@@ -15386,15 +15391,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateSamplerNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load samplers\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load samplers\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF textures
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * textures = Json_GetMemberByName( rootNode, "textures" );
 			scene->textureCount = Json_GetMemberCount( textures );
@@ -15418,15 +15423,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateTextureNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load textures\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load textures\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF shaders
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * shaders = Json_GetMemberByName( rootNode, "shaders" );
 			scene->shaderCount = Json_GetMemberCount( shaders );
@@ -15449,15 +15454,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateShaderNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load shaders\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load shaders\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF programs
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * programs = Json_GetMemberByName( rootNode, "programs" );
 			scene->programCount = Json_GetMemberCount( programs );
@@ -15482,15 +15487,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateProgramNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load programs\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load programs\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF techniques
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * techniques = Json_GetMemberByName( rootNode, "techniques" );
 			scene->techniqueCount = Json_GetMemberCount( techniques );
@@ -15742,15 +15747,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateTechniqueNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load techniques\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load techniques\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF materials
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * materials = Json_GetMemberByName( rootNode, "materials" );
 			scene->materialCount = Json_GetMemberCount( materials );
@@ -15810,15 +15815,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateMaterialNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load materials\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load materials\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF meshes
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * models = Json_GetMemberByName( rootNode, "meshes" );
 			scene->modelCount = Json_GetMemberCount( models );
@@ -15856,10 +15861,10 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 					assert( surface->material != NULL );
 
 					const ksGltfAccessor * positionAccessor		= ksGltf_GetAccessorByNameAndType( scene, positionAccessorName,		"VEC3",		GL_FLOAT );
-					const ksGltfAccessor * normalAccessor		= ksGltf_GetAccessorByNameAndType( scene, normalAccessorName,			"VEC3",		GL_FLOAT );
+					const ksGltfAccessor * normalAccessor		= ksGltf_GetAccessorByNameAndType( scene, normalAccessorName,		"VEC3",		GL_FLOAT );
 					const ksGltfAccessor * tangentAccessor		= ksGltf_GetAccessorByNameAndType( scene, tangentAccessorName,		"VEC3",		GL_FLOAT );
 					const ksGltfAccessor * binormalAccessor		= ksGltf_GetAccessorByNameAndType( scene, binormalAccessorName,		"VEC3",		GL_FLOAT );
-					const ksGltfAccessor * colorAccessor		= ksGltf_GetAccessorByNameAndType( scene, colorAccessorName,			"VEC4",		GL_FLOAT );
+					const ksGltfAccessor * colorAccessor		= ksGltf_GetAccessorByNameAndType( scene, colorAccessorName,		"VEC4",		GL_FLOAT );
 					const ksGltfAccessor * uv0Accessor			= ksGltf_GetAccessorByNameAndType( scene, uv0AccessorName,			"VEC2",		GL_FLOAT );
 					const ksGltfAccessor * uv1Accessor			= ksGltf_GetAccessorByNameAndType( scene, uv1AccessorName,			"VEC2",		GL_FLOAT );
 					const ksGltfAccessor * uv2Accessor			= ksGltf_GetAccessorByNameAndType( scene, uv2AccessorName,			"VEC2",		GL_FLOAT );
@@ -15905,10 +15910,10 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 					ksGpuVertexAttributeArrays_Alloc( &attribs.base, DefaultVertexAttributeLayout, positionAccessor->count, attribFlags );
 
 					if ( positionAccessor != NULL )		memcpy( attribs.position,		ksGltf_GetBufferData( positionAccessor ),		positionAccessor->count		* sizeof( attribs.position[0] ) );
-					if ( normalAccessor != NULL )		memcpy( attribs.normal,			ksGltf_GetBufferData( normalAccessor ),		normalAccessor->count		* sizeof( attribs.normal[0] ) );
+					if ( normalAccessor != NULL )		memcpy( attribs.normal,			ksGltf_GetBufferData( normalAccessor ),			normalAccessor->count		* sizeof( attribs.normal[0] ) );
 					if ( tangentAccessor != NULL )		memcpy( attribs.tangent,		ksGltf_GetBufferData( tangentAccessor ),		tangentAccessor->count		* sizeof( attribs.tangent[0] ) );
 					if ( binormalAccessor != NULL )		memcpy( attribs.binormal,		ksGltf_GetBufferData( binormalAccessor ),		binormalAccessor->count		* sizeof( attribs.binormal[0] ) );
-					if ( colorAccessor != NULL )		memcpy( attribs.color,			ksGltf_GetBufferData( colorAccessor ),		colorAccessor->count		* sizeof( attribs.color[0] ) );
+					if ( colorAccessor != NULL )		memcpy( attribs.color,			ksGltf_GetBufferData( colorAccessor ),			colorAccessor->count		* sizeof( attribs.color[0] ) );
 					if ( uv0Accessor != NULL )			memcpy( attribs.uv0,			ksGltf_GetBufferData( uv0Accessor ),			uv0Accessor->count			* sizeof( attribs.uv0[0] ) );
 					if ( uv1Accessor != NULL )			memcpy( attribs.uv1,			ksGltf_GetBufferData( uv1Accessor ),			uv1Accessor->count			* sizeof( attribs.uv1[0] ) );
 					if ( uv2Accessor != NULL )			memcpy( attribs.uv2,			ksGltf_GetBufferData( uv2Accessor ),			uv2Accessor->count			* sizeof( attribs.uv2[0] ) );
@@ -15934,15 +15939,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateModelNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load models\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load models\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF animations
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * animations = Json_GetMemberByName( rootNode, "animations" );
 			scene->animationCount = Json_GetMemberCount( animations );
@@ -16055,15 +16060,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateAnimationNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load animations\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load animations\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF skins
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * skins = Json_GetMemberByName( rootNode, "skins" );
 			scene->skinCount = Json_GetMemberCount( skins );
@@ -16104,15 +16109,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateSkinNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load skins\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load skins\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF cameras
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * cameras = Json_GetMemberByName( rootNode, "cameras" );
 			scene->cameraCount = Json_GetMemberCount( cameras );
@@ -16151,15 +16156,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateCameraNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load cameras\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load cameras\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF nodes
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * nodes = Json_GetMemberByName( rootNode, "nodes" );
 			scene->nodeCount = Json_GetMemberCount( nodes );
@@ -16215,8 +16220,8 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			ksGltf_CreateNodeNameHash( scene );
 			ksGltf_CreateNodeJointNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load nodes\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load nodes\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
@@ -16336,9 +16341,9 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 		ksGpuGraphicsPipeline_Create( context, &scene->unitCubePipeline, &pipelineParms );
 	}
 
-	const ksMicroseconds t1 = GetTimeMicroseconds();
+	const ksNanoseconds t1 = GetTimeNanoseconds();
 
-	Print( "%1.3f seconds to load %s\n", ( t1 - t0 ) * 1e-6f, fileName );
+	Print( "%1.3f seconds to load %s\n", ( t1 - t0 ) * 1e-9f, fileName );
 
 	return true;
 }
@@ -16522,7 +16527,7 @@ static void ksGltfScene_Destroy( ksGpuContext * context, ksGltfScene * scene )
 	memset( scene, 0, sizeof( ksGltfScene ) );
 }
 
-static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time )
+static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time )
 {
 	// Apply animations to the nodes in the hierarchy.
 	for ( int animIndex = 0; animIndex < scene->animationCount; animIndex++ )
@@ -16533,7 +16538,7 @@ static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, 
 			continue;
 		}
 
-		const float timeInSeconds = fmodf( time * 1e-6f, animation->sampleTimes[animation->sampleCount - 1] - animation->sampleTimes[0] );
+		const float timeInSeconds = fmodf( time * 1e-9f, animation->sampleTimes[animation->sampleCount - 1] - animation->sampleTimes[0] );
 		int frame = 0;
 		for ( int sampleCount = animation->sampleCount; sampleCount > 1; sampleCount >>= 1 )
 		{
@@ -16619,9 +16624,10 @@ static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, 
 
 			ksMatrix4x4f_Multiply( &viewState->viewMatrix[eye], &eyeOffsetMatrix, &viewState->centerViewMatrix );
 			ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye],
-											cameraNode->camera->perspective.fovDegreesX,
-											cameraNode->camera->perspective.fovDegreesY,
-											0.0f, 0.0f,
+											cameraNode->camera->perspective.fovDegreesX * 0.5f,
+											cameraNode->camera->perspective.fovDegreesX * 0.5f,
+											cameraNode->camera->perspective.fovDegreesY * 0.5f,
+											cameraNode->camera->perspective.fovDegreesY * 0.5f,
 											cameraNode->camera->perspective.nearZ, cameraNode->camera->perspective.farZ );
 
 			ksViewState_DerivedData( viewState );
@@ -17021,9 +17027,9 @@ typedef struct
 	bool						hideGraphs;
 	ksTimeWarpImplementation	timeWarpImplementation;
 	ksRenderMode				renderMode;
-	ksMicroseconds				startupTimeMicroseconds;
-	ksMicroseconds				noVSyncMicroseconds;
-	ksMicroseconds				noLogMicroseconds;
+	ksNanoseconds				startupTimeNanoseconds;
+	ksNanoseconds				noVSyncNanoseconds;
+	ksNanoseconds				noLogNanoseconds;
 } ksStartupSettings;
 
 static int ksStartupSettings_StringToLevel( const char * string, const int maxLevels )
@@ -17137,7 +17143,7 @@ void SceneThread_Render( ksSceneThreadData * threadData )
 			ksFrameLog_Open( OUTPUT_PATH "framelog_scene.txt", 10 );
 		}
 
-		const ksMicroseconds nextDisplayTime = ksTimeWarp_GetPredictedDisplayTime( threadData->timeWarp, frameIndex );
+		const ksNanoseconds nextDisplayTime = ksTimeWarp_GetPredictedDisplayTime( threadData->timeWarp, frameIndex );
 
 #if USE_GLTF == 1
 		ksGltfScene_Simulate( &scene, &viewState, threadData->input, nextDisplayTime );
@@ -17147,7 +17153,7 @@ void SceneThread_Render( ksSceneThreadData * threadData )
 
 		ksFrameLog_BeginFrame();
 
-		const ksMicroseconds t0 = GetTimeMicroseconds();
+		const ksNanoseconds t0 = GetTimeNanoseconds();
 
 		ksGpuTexture * eyeTexture[NUM_EYES] = { 0 };
 		ksGpuFence * eyeCompletionFence[NUM_EYES] = { 0 };
@@ -17194,15 +17200,15 @@ void SceneThread_Render( ksSceneThreadData * threadData )
 			eyeCompletionFence[1] = eyeCompletionFence[0];
 		}
 
-		const ksMicroseconds t1 = GetTimeMicroseconds();
+		const ksNanoseconds t1 = GetTimeNanoseconds();
 
-		const float eyeTexturesCpuTime = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-		const float eyeTexturesGpuTime = ksGpuTimer_GetMilliseconds( &eyeTimer[0] ) + ksGpuTimer_GetMilliseconds( &eyeTimer[1] );
+		const ksNanoseconds eyeTexturesCpuTime = t1 - t0;
+		const ksNanoseconds eyeTexturesGpuTime = ksGpuTimer_GetNanoseconds( &eyeTimer[0] ) + ksGpuTimer_GetNanoseconds( &eyeTimer[1] );
 
 		ksFrameLog_EndFrame( eyeTexturesCpuTime, eyeTexturesGpuTime, GPU_TIMER_FRAMES_DELAYED );
 
 		ksMatrix4x4f projectionMatrix;
-		ksMatrix4x4f_CreateProjectionFov( &projectionMatrix, 80.0f, 80.0f, 0.0f, 0.0f, 0.1f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &projectionMatrix, 40.0f, 40.0f, 40.0f, 40.0f, DEFAULT_NEAR_Z, 0.0f );
 
 		ksTimeWarp_SubmitFrame( threadData->timeWarp, frameIndex, nextDisplayTime,
 								&viewState.hmdViewMatrix, &projectionMatrix,
@@ -17280,7 +17286,7 @@ bool RenderAsyncTimeWarp( ksStartupSettings * startupSettings )
 						WINDOW_RESOLUTION( displayResolutionTable[startupSettings->displayResolutionLevel * 2 + 1], startupSettings->fullscreen ),
 						startupSettings->fullscreen );
 
-	int swapInterval = ( startupSettings->noVSyncMicroseconds <= 0 );
+	int swapInterval = ( startupSettings->noVSyncNanoseconds <= 0 );
 	ksGpuWindow_SwapInterval( &window, swapInterval );
 
 	ksTimeWarp timeWarp;
@@ -17313,16 +17319,16 @@ bool RenderAsyncTimeWarp( ksStartupSettings * startupSettings )
 
 	hmd_headRotationDisabled = startupSettings->headRotationDisabled;
 
-	ksMicroseconds startupTimeMicroseconds = startupSettings->startupTimeMicroseconds;
-	ksMicroseconds noVSyncMicroseconds = startupSettings->noVSyncMicroseconds;
-	ksMicroseconds noLogMicroseconds = startupSettings->noLogMicroseconds;
+	ksNanoseconds startupTimeNanoseconds = startupSettings->startupTimeNanoseconds;
+	ksNanoseconds noVSyncNanoseconds = startupSettings->noVSyncNanoseconds;
+	ksNanoseconds noLogNanoseconds = startupSettings->noLogNanoseconds;
 
 	ksThread_SetName( "atw:timewarp" );
 
 	bool exit = false;
 	while ( !exit )
 	{
-		const ksMicroseconds time = GetTimeMicroseconds();
+		const ksNanoseconds time = GetTimeNanoseconds();
 
 		const ksGpuWindowEvent handleEvent = ksGpuWindow_ProcessEvents( &window );
 		if ( handleEvent == GPU_WINDOW_EVENT_ACTIVATED )
@@ -17350,18 +17356,18 @@ bool RenderAsyncTimeWarp( ksStartupSettings * startupSettings )
 			break;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_V ) ||
-			( noVSyncMicroseconds > 0 && time - startupTimeMicroseconds > noVSyncMicroseconds ) )
+			( noVSyncNanoseconds > 0 && time - startupTimeNanoseconds > noVSyncNanoseconds ) )
 		{
 			swapInterval = !swapInterval;
 			ksGpuWindow_SwapInterval( &window, swapInterval );
-			noVSyncMicroseconds = 0;
+			noVSyncNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_L ) ||
-			( noLogMicroseconds > 0 && time - startupTimeMicroseconds > noLogMicroseconds ) )
+			( noLogNanoseconds > 0 && time - startupTimeNanoseconds > noLogNanoseconds ) )
 		{
 			ksFrameLog_Open( OUTPUT_PATH "framelog_timewarp.txt", 10 );
 			sceneThreadData.openFrameLog = true;
-			noLogMicroseconds = 0;
+			noLogNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_H ) )
 		{
@@ -17473,7 +17479,7 @@ bool RenderTimeWarp( ksStartupSettings * startupSettings )
 						WINDOW_RESOLUTION( displayResolutionTable[startupSettings->displayResolutionLevel * 2 + 1], startupSettings->fullscreen ),
 						startupSettings->fullscreen );
 
-	int swapInterval = ( startupSettings->noVSyncMicroseconds <= 0 );
+	int swapInterval = ( startupSettings->noVSyncNanoseconds <= 0 );
 	ksGpuWindow_SwapInterval( &window, swapInterval );
 
 	ksTimeWarp timeWarp;
@@ -17485,16 +17491,16 @@ bool RenderTimeWarp( ksStartupSettings * startupSettings )
 
 	hmd_headRotationDisabled = startupSettings->headRotationDisabled;
 
-	ksMicroseconds startupTimeMicroseconds = startupSettings->startupTimeMicroseconds;
-	ksMicroseconds noVSyncMicroseconds = startupSettings->noVSyncMicroseconds;
-	ksMicroseconds noLogMicroseconds = startupSettings->noLogMicroseconds;
+	ksNanoseconds startupTimeNanoseconds = startupSettings->startupTimeNanoseconds;
+	ksNanoseconds noVSyncNanoseconds = startupSettings->noVSyncNanoseconds;
+	ksNanoseconds noLogNanoseconds = startupSettings->noLogNanoseconds;
 
 	ksThread_SetName( "atw:timewarp" );
 
 	bool exit = false;
 	while ( !exit )
 	{
-		const ksMicroseconds time = GetTimeMicroseconds();
+		const ksNanoseconds time = GetTimeNanoseconds();
 
 		const ksGpuWindowEvent handleEvent = ksGpuWindow_ProcessEvents( &window );
 		if ( handleEvent == GPU_WINDOW_EVENT_ACTIVATED )
@@ -17521,17 +17527,17 @@ bool RenderTimeWarp( ksStartupSettings * startupSettings )
 			break;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_V ) ||
-			( noVSyncMicroseconds > 0 && time - startupTimeMicroseconds > noVSyncMicroseconds ) )
+			( noVSyncNanoseconds > 0 && time - startupTimeNanoseconds > noVSyncNanoseconds ) )
 		{
 			swapInterval = !swapInterval;
 			ksGpuWindow_SwapInterval( &window, swapInterval );
-			noVSyncMicroseconds = 0;
+			noVSyncNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_L ) ||
-			( noLogMicroseconds > 0 && time - startupTimeMicroseconds > noLogMicroseconds ) )
+			( noLogNanoseconds > 0 && time - startupTimeNanoseconds > noLogNanoseconds ) )
 		{
 			ksFrameLog_Open( OUTPUT_PATH "framelog_timewarp.txt", 10 );
-			noLogMicroseconds = 0;
+			noLogNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_H ) )
 		{
@@ -17606,7 +17612,7 @@ bool RenderScene( ksStartupSettings * startupSettings )
 						WINDOW_RESOLUTION( displayResolutionTable[startupSettings->displayResolutionLevel * 2 + 1], startupSettings->fullscreen ),
 						startupSettings->fullscreen );
 
-	int swapInterval = ( startupSettings->noVSyncMicroseconds <= 0 );
+	int swapInterval = ( startupSettings->noVSyncNanoseconds <= 0 );
 	ksGpuWindow_SwapInterval( &window, swapInterval );
 
 	ksGpuRenderPass renderPass;
@@ -17653,16 +17659,16 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 	hmd_headRotationDisabled = startupSettings->headRotationDisabled;
 
-	ksMicroseconds startupTimeMicroseconds = startupSettings->startupTimeMicroseconds;
-	ksMicroseconds noVSyncMicroseconds = startupSettings->noVSyncMicroseconds;
-	ksMicroseconds noLogMicroseconds = startupSettings->noLogMicroseconds;
+	ksNanoseconds startupTimeNanoseconds = startupSettings->startupTimeNanoseconds;
+	ksNanoseconds noVSyncNanoseconds = startupSettings->noVSyncNanoseconds;
+	ksNanoseconds noLogNanoseconds = startupSettings->noLogNanoseconds;
 
 	ksThread_SetName( "atw:scene" );
 
 	bool exit = false;
 	while ( !exit )
 	{
-		const ksMicroseconds time = GetTimeMicroseconds();
+		const ksNanoseconds time = GetTimeNanoseconds();
 
 		const ksGpuWindowEvent handleEvent = ksGpuWindow_ProcessEvents( &window );
 		if ( handleEvent == GPU_WINDOW_EVENT_ACTIVATED )
@@ -17690,17 +17696,17 @@ bool RenderScene( ksStartupSettings * startupSettings )
 			break;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_V ) ||
-			( noVSyncMicroseconds > 0 && time - startupTimeMicroseconds > noVSyncMicroseconds ) )
+			( noVSyncNanoseconds > 0 && time - startupTimeNanoseconds > noVSyncNanoseconds ) )
 		{
 			swapInterval = !swapInterval;
 			ksGpuWindow_SwapInterval( &window, swapInterval );
-			noVSyncMicroseconds = 0;
+			noVSyncNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_L ) ||
-			( noLogMicroseconds > 0 && time - startupTimeMicroseconds > noLogMicroseconds ) )
+			( noLogNanoseconds > 0 && time - startupTimeNanoseconds > noLogNanoseconds ) )
 		{
 			ksFrameLog_Open( OUTPUT_PATH "framelog_scene.txt", 10 );
-			noLogMicroseconds = 0;
+			noLogNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_H ) )
 		{
@@ -17747,7 +17753,7 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 		if ( window.windowActive )
 		{
-			const ksMicroseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeMicroseconds( &window );
+			const ksNanoseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeNanoseconds( &window );
 
 #if USE_GLTF == 1
 			ksGltfScene_Simulate( &scene, &viewState, &window.input, nextSwapTime );
@@ -17757,7 +17763,7 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 			ksFrameLog_BeginFrame();
 
-			const ksMicroseconds t0 = GetTimeMicroseconds();
+			const ksNanoseconds t0 = GetTimeNanoseconds();
 
 			const ksScreenRect screenRect = ksGpuFramebuffer_GetRect( &framebuffer );
 
@@ -17796,15 +17802,15 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 			ksGpuCommandBuffer_SubmitPrimary( &commandBuffer );
 
-			const ksMicroseconds t1 = GetTimeMicroseconds();
+			const ksNanoseconds t1 = GetTimeNanoseconds();
 
-			const float sceneCpuTimeMilliseconds = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-			const float sceneGpuTimeMilliseconds = ksGpuTimer_GetMilliseconds( &timer );
+			const ksNanoseconds sceneCpuTime = t1 - t0;
+			const ksNanoseconds sceneGpuTime = ksGpuTimer_GetNanoseconds( &timer );
 
-			ksFrameLog_EndFrame( sceneCpuTimeMilliseconds, sceneGpuTimeMilliseconds, GPU_TIMER_FRAMES_DELAYED );
+			ksFrameLog_EndFrame( sceneCpuTime, sceneGpuTime, GPU_TIMER_FRAMES_DELAYED );
 
-			ksBarGraph_AddBar( &frameCpuTimeBarGraph, 0, sceneCpuTimeMilliseconds * window.windowRefreshRate * ( 1.0f / 1000.0f ), &colorGreen, true );
-			ksBarGraph_AddBar( &frameGpuTimeBarGraph, 0, sceneGpuTimeMilliseconds * window.windowRefreshRate * ( 1.0f / 1000.0f ), &colorGreen, true );
+			ksBarGraph_AddBar( &frameCpuTimeBarGraph, 0, sceneCpuTime * window.windowRefreshRate * 1e-9f, &colorGreen, true );
+			ksBarGraph_AddBar( &frameGpuTimeBarGraph, 0, sceneGpuTime * window.windowRefreshRate * 1e-9f, &colorGreen, true );
 
 			ksGpuWindow_SwapBuffers( &window );
 		}
@@ -17839,7 +17845,7 @@ static int StartApplication( int argc, char * argv[] )
 {
 	ksStartupSettings startupSettings;
 	memset( &startupSettings, 0, sizeof( startupSettings ) );
-	startupSettings.startupTimeMicroseconds = GetTimeMicroseconds();
+	startupSettings.startupTimeNanoseconds = GetTimeNanoseconds();
 	
 	for ( int i = 1; i < argc; i++ )
 	{
@@ -17847,7 +17853,7 @@ static int StartApplication( int argc, char * argv[] )
 		if ( arg[0] == '-' ) { arg++; }
 
 		if ( strcmp( arg, "f" ) == 0 && i + 0 < argc )		{ startupSettings.fullscreen = true; }
-		else if ( strcmp( arg, "v" ) == 0 && i + 1 < argc )	{ startupSettings.noVSyncMicroseconds = (ksMicroseconds)( atof( argv[++i] ) * 1000 * 1000 ); }
+		else if ( strcmp( arg, "v" ) == 0 && i + 1 < argc )	{ startupSettings.noVSyncNanoseconds = (ksNanoseconds)( atof( argv[++i] ) * 1000 * 1000 * 1000 ); }
 		else if ( strcmp( arg, "h" ) == 0 && i + 0 < argc )	{ startupSettings.headRotationDisabled = true; }
 		else if ( strcmp( arg, "p" ) == 0 && i + 0 < argc )	{ startupSettings.simulationPaused = true; }
 		else if ( strcmp( arg, "r" ) == 0 && i + 1 < argc )	{ startupSettings.displayResolutionLevel = ksStartupSettings_StringToLevel( argv[++i], MAX_DISPLAY_RESOLUTION_LEVELS ); }
@@ -17861,7 +17867,7 @@ static int StartApplication( int argc, char * argv[] )
 		else if ( strcmp( arg, "i" ) == 0 && i + 1 < argc )	{ startupSettings.timeWarpImplementation = (ksTimeWarpImplementation)ksStartupSettings_StringToTimeWarpImplementation( argv[++i] ); }
 		else if ( strcmp( arg, "z" ) == 0 && i + 1 < argc )	{ startupSettings.renderMode = ksStartupSettings_StringToRenderMode( argv[++i] ); }
 		else if ( strcmp( arg, "g" ) == 0 && i + 0 < argc )	{ startupSettings.hideGraphs = true; }
-		else if ( strcmp( arg, "l" ) == 0 && i + 1 < argc )	{ startupSettings.noLogMicroseconds = (ksMicroseconds)( atof( argv[++i] ) * 1000 * 1000 ); }
+		else if ( strcmp( arg, "l" ) == 0 && i + 1 < argc )	{ startupSettings.noLogNanoseconds = (ksNanoseconds)( atof( argv[++i] ) * 1000 * 1000 * 1000 ); }
 		else if ( strcmp( arg, "d" ) == 0 && i + 0 < argc )	{ DumpGLSL(); exit( 0 ); }
 		else
 		{
@@ -17899,7 +17905,7 @@ static int StartApplication( int argc, char * argv[] )
 	//startupSettings.timeWarpImplementation = TIMEWARP_IMPLEMENTATION_COMPUTE;
 
 	Print( "    fullscreen = %d\n",					startupSettings.fullscreen );
-	Print( "    noVSyncMicroseconds = %lld\n",		startupSettings.noVSyncMicroseconds );
+	Print( "    noVSyncNanoseconds = %lld\n",		startupSettings.noVSyncNanoseconds );
 	Print( "    headRotationDisabled = %d\n",		startupSettings.headRotationDisabled );
 	Print( "    simulationPaused = %d\n",			startupSettings.simulationPaused );
 	Print( "    displayResolutionLevel = %d\n",		startupSettings.displayResolutionLevel );
@@ -17913,7 +17919,7 @@ static int StartApplication( int argc, char * argv[] )
 	Print( "    timeWarpImplementation = %d\n",		startupSettings.timeWarpImplementation );
 	Print( "    renderMode = %d\n",					startupSettings.renderMode );
 	Print( "    hideGraphs = %d\n",					startupSettings.hideGraphs );
-	Print( "    noLogMicroseconds = %lld\n",		startupSettings.noLogMicroseconds );
+	Print( "    noLogNanoseconds = %lld\n",			startupSettings.noLogNanoseconds );
 
 	for ( bool exit = false; !exit; )
 	{

--- a/samples/apps/atw/atw_vulkan.c
+++ b/samples/apps/atw/atw_vulkan.c
@@ -10800,7 +10800,7 @@ static ksNanoseconds ksGpuTimer_GetNanoseconds( ksGpuTimer * timer );
 typedef struct
 {
 	VkBool32			supported;
-	ksNanoseconds			period;
+	ksNanoseconds		period;
 	VkQueryPool			pool;
 	uint32_t			init;
 	uint32_t			index;
@@ -10817,7 +10817,7 @@ static void ksGpuTimer_Create( ksGpuContext * context, ksGpuTimer * timer )
 		return;
 	}
 
-	timer->period = (ksNanoseconds)context->device->physicalDeviceProperties.limits.timestampPeriod;
+	timer->period = (ksNanoseconds) context->device->physicalDeviceProperties.limits.timestampPeriod;
 
 	const uint32_t queryCount = ( GPU_TIMER_FRAMES_DELAYED + 1 ) * 2;
 
@@ -13426,6 +13426,7 @@ static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksNanoseco
 		return;
 	}
 
+	// FIXME: use double?
 	const float offset = time * ( MATH_PI / 1000.0f / 1000.0f / 1000.0f );
 	const float degrees = 10.0f;
 	const float degreesX = sinf( offset ) * degrees;

--- a/samples/apps/atw/atw_vulkan.c
+++ b/samples/apps/atw/atw_vulkan.c
@@ -259,7 +259,7 @@ features. Some of the current limitations are:
   it is advised to use a uniform buffer, which is the preferred approach for
   exposing large amounts of data anyway.
 
-- Graphics programs currently consist of only of a vertex and fragment shader.
+- Graphics programs currently consist of only a vertex and fragment shader.
   This can be easily extended if there is a need for geometry shaders etc.
 
 
@@ -558,7 +558,7 @@ Platform headers / declarations
 
 #endif
 
-#if defined(OS_NEUTRAL_DISPLAY_SURFACE)
+#if defined( OS_NEUTRAL_DISPLAY_SURFACE )
 	#define VK_KHR_PLATFORM_SURFACE_EXTENSION_NAME	VK_KHR_DISPLAY_EXTENSION_NAME
 	#define PFN_vkCreateSurfaceKHR					PFN_vkCreateDisplayPlaneSurfaceKHR
 	#define vkCreateSurfaceKHR						vkCreateDisplayPlaneSurfaceKHR
@@ -574,6 +574,7 @@ Common headers
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <math.h>
 #include <assert.h>
 #include <string.h>			// for memset
@@ -936,43 +937,51 @@ static const char * GetCPUVersion()
 	return "unknown";
 }
 
-typedef unsigned long long ksMicroseconds;
+typedef uint64_t ksNanoseconds;
 
-static ksMicroseconds GetTimeMicroseconds()
+static ksNanoseconds GetTimeNanoseconds()
 {
 #if defined( OS_WINDOWS )
-	static ksMicroseconds ticksPerSecond = 0;
-	static ksMicroseconds timeBase = 0;
+	static ksNanoseconds ticksPerSecond = 0;
+	static ksNanoseconds timeBase = 0;
 
 	if ( ticksPerSecond == 0 )
 	{
 		LARGE_INTEGER li;
 		QueryPerformanceFrequency( &li );
-		ticksPerSecond = (ksMicroseconds) li.QuadPart;
+		ticksPerSecond = (ksNanoseconds) li.QuadPart;
 		QueryPerformanceCounter( &li );
-		timeBase = (ksMicroseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
+		timeBase = (ksNanoseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
 	}
 
 	LARGE_INTEGER li;
 	QueryPerformanceCounter( &li );
-	ksMicroseconds counter = (ksMicroseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
-	return ( counter - timeBase ) * 1000ULL * 1000ULL / ticksPerSecond;
+	ksNanoseconds counter = (ksNanoseconds) li.LowPart + 0xFFFFFFFFULL * li.HighPart;
+	return ( counter - timeBase ) * 1000ULL * 1000ULL * 1000ULL / ticksPerSecond;
 #elif defined( OS_ANDROID )
+	static ksNanoseconds timeBase = 0;
+
 	struct timespec ts;
 	clock_gettime( CLOCK_MONOTONIC, &ts );
-	return (ksMicroseconds) ts.tv_sec * 1000ULL * 1000ULL + ts.tv_nsec / 1000ULL;
+
+	if ( timeBase == 0 )
+	{
+		timeBase = (ksNanoseconds) ts.tv_sec * 1000ULL * 1000ULL * 1000ULL + ts.tv_nsec;
+	}
+
+	return (ksNanoseconds) ts.tv_sec * 1000ULL * 1000ULL * 1000ULL + ts.tv_nsec - timeBase;
 #else
-	static ksMicroseconds timeBase = 0;
+	static ksNanoseconds timeBase = 0;
 
 	struct timeval tv;
 	gettimeofday( &tv, 0 );
 
 	if ( timeBase == 0 )
 	{
-		timeBase = (ksMicroseconds) tv.tv_sec * 1000ULL * 1000ULL;
+		timeBase = (ksNanoseconds) tv.tv_sec * 1000ULL * 1000ULL * 1000ULL + tv.tv_usec * 1000ULL;
 	}
 
-	return (ksMicroseconds) tv.tv_sec * 1000ULL * 1000ULL + tv.tv_usec - timeBase;
+	return (ksNanoseconds) tv.tv_sec * 1000ULL * 1000ULL * 1000ULL + tv.tv_usec * 1000ULL - timeBase;
 #endif
 }
 
@@ -1110,7 +1119,7 @@ ksSignal
 
 static void ksSignal_Create( ksSignal * signal, const bool autoReset );
 static void ksSignal_Destroy( ksSignal * signal );
-static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicroseconds );
+static bool ksSignal_Wait( ksSignal * signal, const ksNanoseconds timeOutNanoseconds );
 static void ksSignal_Raise( ksSignal * signal );
 static void ksSignal_Clear( ksSignal * signal );
 
@@ -1157,13 +1166,13 @@ static void ksSignal_Destroy( ksSignal * signal )
 
 // Waits for the object to enter the signalled state and returns true if this state is reached within the time-out period.
 // If 'autoReset' is true then the first thread that reaches the signalled state within the time-out period will clear the signalled state.
-// If 'timeOutMicroseconds' is SIGNAL_TIMEOUT_INFINITE then this will wait indefinitely until the signalled state is reached.
+// If 'timeOutNanoseconds' is SIGNAL_TIMEOUT_INFINITE then this will wait indefinitely until the signalled state is reached.
 // Returns true if the thread was released because the object entered the signalled state, returns false if the time-out is reached first.
-static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicroseconds )
+static bool ksSignal_Wait( ksSignal * signal, const ksNanoseconds timeOutNanoseconds )
 {
 #if defined( OS_WINDOWS )
-	DWORD result = WaitForSingleObject( signal->handle, ( timeOutMicroseconds == SIGNAL_TIMEOUT_INFINITE ) ? INFINITE : (DWORD)( timeOutMicroseconds / 1000 ) );
-	assert( result == WAIT_OBJECT_0 || ( timeOutMicroseconds != SIGNAL_TIMEOUT_INFINITE && result == WAIT_TIMEOUT ) );
+	DWORD result = WaitForSingleObject( signal->handle, ( timeOutNanoseconds == SIGNAL_TIMEOUT_INFINITE ) ? INFINITE : (DWORD)( timeOutNanoseconds / ( 1000 * 1000 ) ) );
+	assert( result == WAIT_OBJECT_0 || ( timeOutNanoseconds != SIGNAL_TIMEOUT_INFINITE && result == WAIT_TIMEOUT ) );
 	return ( result == WAIT_OBJECT_0 );
 #else
 	bool released = false;
@@ -1175,7 +1184,7 @@ static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicros
 	else
 	{
 		signal->waitCount++;
-		if ( timeOutMicroseconds == SIGNAL_TIMEOUT_INFINITE )
+		if ( timeOutNanoseconds == SIGNAL_TIMEOUT_INFINITE )
 		{
 			do
 			{
@@ -1183,13 +1192,13 @@ static bool ksSignal_Wait( ksSignal * signal, const ksMicroseconds timeOutMicros
 				// Must re-check condition because pthread_cond_wait may spuriously wake up.
 			} while ( signal->signaled == false );
 		}
-		else if ( timeOutMicroseconds > 0 )
+		else if ( timeOutNanoseconds > 0 )
 		{
 			struct timeval tp;
 			gettimeofday( &tp, NULL );
 			struct timespec ts;
-			ts.tv_sec = (time_t)( tp.tv_sec + timeOutMicroseconds / 1000000 );
-			ts.tv_nsec = (long)( ( tp.tv_usec + ( timeOutMicroseconds % 1000000 ) ) * 1000 );
+			ts.tv_sec = (time_t)( tp.tv_sec + timeOutNanoseconds / ( 1000 * 1000 * 1000 ) );
+			ts.tv_nsec = (long)( tp.tv_usec + ( timeOutNanoseconds % ( 1000 * 1000 * 1000 ) ) );
 			do
 			{
 				if ( pthread_cond_timedwait( &signal->cond, &signal->mutex, &ts ) == ETIMEDOUT )
@@ -1664,18 +1673,18 @@ ksFrameLog
 static void ksFrameLog_Open( const char * fileName, const int frameCount );
 static void ksFrameLog_Write( const char * fileName, const int lineNumber, const char * function );
 static void ksFrameLog_BeginFrame();
-static void ksFrameLog_EndFrame( const float cpuTimeMilliseconds, const float gpuTimeMilliseconds, const int gpuTimeFramesDelayed );
+static void ksFrameLog_EndFrame( const ksNanoseconds cpuTimeNanoseconds, const ksNanoseconds gpuTimeNanoseconds, const int gpuTimeFramesDelayed );
 
 ================================================================================================================================
 */
 
 typedef struct
 {
-	FILE *		fp;
-	float *		frameCpuTimes;
-	float *		frameGpuTimes;
-	int			frameCount;
-	int			frame;
+	FILE *			fp;
+	ksNanoseconds *	frameCpuTimes;
+	ksNanoseconds *	frameGpuTimes;
+	int				frameCount;
+	int				frame;
 } ksFrameLog;
 
 __thread ksFrameLog * threadFrameLog;
@@ -1705,8 +1714,8 @@ static void ksFrameLog_Open( const char * fileName, const int frameCount )
 		else
 		{
 			Print( "Opened frame log %s for %d frames.\n", fileName, frameCount );
-			l->frameCpuTimes = (float *) malloc( frameCount * sizeof( l->frameCpuTimes[0] ) );
-			l->frameGpuTimes = (float *) malloc( frameCount * sizeof( l->frameGpuTimes[0] ) );
+			l->frameCpuTimes = (ksNanoseconds *) malloc( frameCount * sizeof( l->frameCpuTimes[0] ) );
+			l->frameGpuTimes = (ksNanoseconds *) malloc( frameCount * sizeof( l->frameGpuTimes[0] ) );
 			memset( l->frameCpuTimes, 0, frameCount * sizeof( l->frameCpuTimes[0] ) );
 			memset( l->frameGpuTimes, 0, frameCount * sizeof( l->frameGpuTimes[0] ) );
 			l->frameCount = frameCount;
@@ -1741,21 +1750,21 @@ static void ksFrameLog_BeginFrame()
 	}
 }
 
-static void ksFrameLog_EndFrame( const float cpuTimeMilliseconds, const float gpuTimeMilliseconds, const int gpuTimeFramesDelayed )
+static void ksFrameLog_EndFrame( const ksNanoseconds cpuTimeNanoseconds, const ksNanoseconds gpuTimeNanoseconds, const int gpuTimeFramesDelayed )
 {
 	ksFrameLog * l = ksFrameLog_Get();
 	if ( l != NULL && l->fp != NULL )
 	{
 		if ( l->frame < l->frameCount )
 		{
-			l->frameCpuTimes[l->frame] = cpuTimeMilliseconds;
+			l->frameCpuTimes[l->frame] = cpuTimeNanoseconds;
 #if defined( _DEBUG )
 			fprintf( l->fp, "================ END FRAME %d ================\r\n", l->frame );
 #endif
 		}
 		if ( l->frame >= gpuTimeFramesDelayed && l->frame < l->frameCount + gpuTimeFramesDelayed )
 		{
-			l->frameGpuTimes[l->frame - gpuTimeFramesDelayed] = gpuTimeMilliseconds;
+			l->frameGpuTimes[l->frame - gpuTimeFramesDelayed] = gpuTimeNanoseconds;
 		}
 
 		l->frame++;
@@ -1764,7 +1773,7 @@ static void ksFrameLog_EndFrame( const float cpuTimeMilliseconds, const float gp
 		{
 			for ( int i = 0; i < l->frameCount; i++ )
 			{
-				fprintf( l->fp, "frame %d: CPU = %1.1f ms, GPU = %1.1f ms\r\n", i, l->frameCpuTimes[i], l->frameGpuTimes[i] );
+				fprintf( l->fp, "frame %d: CPU = %1.1f ms, GPU = %1.1f ms\r\n", i, l->frameCpuTimes[i] * 1e-6f, l->frameGpuTimes[i] * 1e-6f );
 			}
 
 			Print( "Closing frame log file (%d frames).\n", l->frameCount );
@@ -1817,10 +1826,10 @@ static void ksMatrix4x4f_CreateTranslation( ksMatrix4x4f * result, const float x
 static void ksMatrix4x4f_CreateRotation( ksMatrix4x4f * result, const float degreesX, const float degreesY, const float degreesZ );
 static void ksMatrix4x4f_CreateScale( ksMatrix4x4f * result, const float x, const float y, const float z );
 static void ksMatrix4x4f_CreateTranslationRotationScale( ksMatrix4x4f * result, const ksVector3f * scale, const ksQuatf * rotation, const ksVector3f * translation );
-static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float minX, const float maxX,
-											float const minY, const float maxY, const float nearZ, const float farZ );
-static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesX, const float fovDegreesY,
-											const float offsetX, const float offsetY, const float nearZ, const float farZ );
+static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float tanAngleLeft, const float tanAngleRight,
+											const float tanAngleUp, float const tanAngleDown, const float nearZ, const float farZ );
+static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesLeft, const float fovDegreesRight,
+											const float fovDegreeUp, const float fovDegreesDown, const float nearZ, const float farZ );
 static void ksMatrix4x4f_CreateFromQuaternion( ksMatrix3x4f * result, const ksQuatf * src );
 static void ksMatrix4x4f_CreateOffsetScaleForBounds( ksMatrix4x4f * result, const ksMatrix4x4f * matrix, const ksVector3f * mins, const ksVector3f * maxs );
 
@@ -1846,6 +1855,8 @@ static bool ksMatrix4x4f_CullBounds( const ksMatrix4x4f * mvp, const ksVector3f 
 
 ================================================================================================================================
 */
+
+#define DEFAULT_NEAR_Z		0.015625f		// exact floating point representation
 
 // 2D integer vector
 typedef struct
@@ -2308,17 +2319,17 @@ static void ksMatrix4x4f_CreateTranslationRotationScale( ksMatrix4x4f * result, 
 //		"Tightening the Precision of Perspective Rendering"
 //		Paul Upchurch, Mathieu Desbrun
 //		Journal of Graphics Tools, Volume 16, Issue 1, 2012
-static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float minX, const float maxX,
-											float const minY, const float maxY, const float nearZ, const float farZ )
+static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float tanAngleLeft, const float tanAngleRight,
+											const float tanAngleUp, float const tanAngleDown, const float nearZ, const float farZ )
 {
-	const float width = maxX - minX;
+	const float tanAngleWidth = tanAngleRight - tanAngleLeft;
 
 #if defined( GRAPHICS_API_VULKAN )
-	// Set to minY - maxY for a clip space with positive Y down (Vulkan).
-	const float height = minY - maxY;
+	// Set to tanAngleDown - tanAngleUp for a clip space with positive Y down (Vulkan).
+	const float tanAngleHeight = tanAngleDown - tanAngleUp;
 #else
-	// Set to maxY - minY for a clip space with positive Y up (OpenGL / D3D).
-	const float height = maxY - minY;
+	// Set to tanAngleUp - tanAngleDown for a clip space with positive Y up (OpenGL / D3D).
+	const float tanAngleHeight = tanAngleUp - tanAngleDown;
 #endif
 
 #if defined( GRAPHICS_API_OPENGL )
@@ -2332,14 +2343,14 @@ static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float mi
 	if ( farZ <= nearZ )
 	{
 		// place the far plane at infinity
-		result->m[0][0] = 2 * nearZ / width;
+		result->m[0][0] = 2 / tanAngleWidth;
 		result->m[1][0] = 0;
-		result->m[2][0] = ( maxX + minX ) / width;
+		result->m[2][0] = ( tanAngleRight + tanAngleLeft ) / tanAngleWidth;
 		result->m[3][0] = 0;
 
 		result->m[0][1] = 0;
-		result->m[1][1] = 2 * nearZ / height;
-		result->m[2][1] = ( maxY + minY ) / height;
+		result->m[1][1] = 2 / tanAngleHeight;
+		result->m[2][1] = ( tanAngleUp + tanAngleDown ) / tanAngleHeight;
 		result->m[3][1] = 0;
 
 		result->m[0][2] = 0;
@@ -2355,14 +2366,14 @@ static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float mi
 	else
 	{
 		// normal projection
-		result->m[0][0] = 2 * nearZ / width;
+		result->m[0][0] = 2 / tanAngleWidth;
 		result->m[1][0] = 0;
-		result->m[2][0] = ( maxX + minX ) / width;
+		result->m[2][0] = ( tanAngleRight + tanAngleLeft ) / tanAngleWidth;
 		result->m[3][0] = 0;
 
 		result->m[0][1] = 0;
-		result->m[1][1] = 2 * nearZ / height;
-		result->m[2][1] = ( maxY + minY ) / height;
+		result->m[1][1] = 2 / tanAngleHeight;
+		result->m[2][1] = ( tanAngleUp + tanAngleDown ) / tanAngleHeight;
 		result->m[3][1] = 0;
 
 		result->m[0][2] = 0;
@@ -2378,19 +2389,16 @@ static void ksMatrix4x4f_CreateProjection( ksMatrix4x4f * result, const float mi
 }
 
 // Creates a projection matrix based on the specified FOV.
-static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesX, const float fovDegreesY,
-												const float offsetX, const float offsetY, const float nearZ, const float farZ )
+static void ksMatrix4x4f_CreateProjectionFov( ksMatrix4x4f * result, const float fovDegreesLeft, const float fovDegreesRight,
+												const float fovDegreesUp, const float fovDegreesDown, const float nearZ, const float farZ )
 {
-	const float halfWidth = nearZ * tanf( fovDegreesX * ( 0.5f * MATH_PI / 180.0f ) );
-	const float halfHeight = nearZ * tanf( fovDegreesY * ( 0.5f * MATH_PI / 180.0f ) );
+	const float tanLeft = - tanf( fovDegreesLeft * ( MATH_PI / 180.0f ) );
+	const float tanRight = tanf( fovDegreesRight * ( MATH_PI / 180.0f ) );
 
-	const float minX = offsetX - halfWidth;
-	const float maxX = offsetX + halfWidth;
+	const float tanDown = - tanf( fovDegreesDown * ( MATH_PI / 180.0f ) );
+	const float tanUp = tanf( fovDegreesUp * ( MATH_PI / 180.0f ) );
 
-	const float minY = offsetY - halfHeight;
-	const float maxY = offsetY + halfHeight;
-
-	ksMatrix4x4f_CreateProjection( result, minX, maxX, minY, maxY, nearZ, farZ );
+	ksMatrix4x4f_CreateProjection( result, tanLeft, tanRight, tanUp, tanDown, nearZ, farZ );
 }
 
 // Creates a matrix that transforms the -1 to 1 cube to cover the given 'mins' and 'maxs' transformed with the given 'matrix'.
@@ -2904,6 +2912,12 @@ VkBool32 DebugReportCallback( VkDebugReportFlagsEXT msgFlags, VkDebugReportObjec
 	// This performance warning is valid but this is how the the secondary command buffer is used.
 	// [DS] "vkBeginCommandBuffer(): Secondary Command Buffers (00000039460DB2F8) may perform better if a valid framebuffer parameter is specified."
 	if ( MatchStrings( pMsg, "vkBeginCommandBuffer(): Secondary Command Buffers (00000039460DB2F8) may perform better if a valid framebuffer parameter is specified." ) )
+	{
+		return VK_FALSE;
+	}
+
+	// [DS] "Cannot get query results on queryPool 0x1b3 with index 4 which is in flight."
+	if ( MatchStrings( pMsg, "Cannot get query results on queryPool 0x1b3 with index 4 which is in flight." ) )
 	{
 		return VK_FALSE;
 	}
@@ -4062,7 +4076,7 @@ ksGpuSwapchain
 static bool ksGpuSwapchain_Create( ksGpuContext * context, ksGpuSwapchain * swapchain, const VkSurfaceKHR surface,
 								const ksGpuSurfaceColorFormat colorFormat, const int width, const int height, const int swapInterval );
 static void ksGpuSwapchain_Destroy( ksGpuContext * context, ksGpuSwapchain * swapchain );
-static ksMicroseconds ksGpuSwapchain_SwapBuffers( ksGpuContext * context, ksGpuSwapchain * swapchain );
+static ksNanoseconds ksGpuSwapchain_SwapBuffers( ksGpuContext * context, ksGpuSwapchain * swapchain );
 
 ================================================================================================================================
 */
@@ -4404,7 +4418,7 @@ static void ksGpuSwapchain_Destroy( ksGpuContext * context, ksGpuSwapchain * swa
 	memset( swapchain, 0, sizeof( ksGpuSwapchain ) );
 }
 
-static ksMicroseconds ksGpuSwapchain_SwapBuffers( ksGpuContext * context, ksGpuSwapchain * swapchain )
+static ksNanoseconds ksGpuSwapchain_SwapBuffers( ksGpuContext * context, ksGpuSwapchain * swapchain )
 {
 	ksGpuDevice * device = context->device;
 
@@ -4430,7 +4444,7 @@ static ksMicroseconds ksGpuSwapchain_SwapBuffers( ksGpuContext * context, ksGpuS
 	// There should be no need to handle VK_SUBOPTIMAL_WSI and VK_ERROR_OUT_OF_DATE_WSI because the window size is fixed.
 	VK( device->vkQueuePresentKHR( swapchain->presentQueue, &presentInfo ) );
 
-	const ksMicroseconds swapTime = GetTimeMicroseconds();
+	const ksNanoseconds swapTime = GetTimeNanoseconds();
 
 	//
 	// Fetch the next image from the swapchain.
@@ -4635,8 +4649,8 @@ static void ksGpuWindow_Exit( ksGpuWindow * window );
 static ksGpuWindowEvent ksGpuWindow_ProcessEvents( ksGpuWindow * window );
 static void ksGpuWindow_SwapInterval( ksGpuWindow * window, const int swapInterval );
 static void ksGpuWindow_SwapBuffers( ksGpuWindow * window );
-static ksMicroseconds ksGpuWindow_GetNextSwapTimeMicroseconds( ksGpuWindow * window );
-static ksMicroseconds ksGpuWindow_GetFrameTimeMicroseconds( ksGpuWindow * window );
+static ksNanoseconds ksGpuWindow_GetNextSwapTimeNanoseconds( ksGpuWindow * window );
+static ksNanoseconds ksGpuWindow_GetFrameTimeNanoseconds( ksGpuWindow * window );
 
 static bool ksGpuWindowInput_ConsumeKeyboardKey( ksGpuWindowInput * input, const ksKeyboardKey key );
 static bool ksGpuWindowInput_ConsumeMouseButton( ksGpuWindowInput * input, const ksMouseButton button );
@@ -4676,7 +4690,7 @@ typedef struct
 	bool					windowActive;
 	bool					windowExit;
 	ksGpuWindowInput		input;
-	ksMicroseconds			lastSwapTime;
+	ksNanoseconds			lastSwapTime;
 
 	// The swapchain and depth buffer could be stored on the context like OpenGL but this makes more sense.
 	VkSurfaceKHR			surface;
@@ -4916,7 +4930,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowActive = false;
 	window->windowExit = false;
 	window->windowActiveState = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	const LPCTSTR displayDevice = NULL;
 
@@ -5218,7 +5232,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 	window->uiView = myUIView;
 	window->uiWindow = myUIWindow;
 
@@ -5409,7 +5423,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	// Get a list of all available displays.
 	CGDirectDisplayID displays[32];
@@ -6037,7 +6051,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	const char * displayName = NULL;
 	window->xDisplay = XOpenDisplay( displayName );
@@ -6497,7 +6511,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	const char * displayName = NULL;
 	int screen_number = 0;
@@ -6799,7 +6813,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = fullscreen;
 	window->windowActive = true;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	VkSurfaceKHR surface;
 	ksGpuDevice_Create( &window->device, instance, GPU_DEVICE_CREATE_PHYSICAL_DEVICE, queueInfo, VK_NULL_HANDLE );
@@ -7105,7 +7119,7 @@ static bool ksGpuWindow_Create( ksGpuWindow * window, ksDriverInstance * instanc
 	window->windowFullscreen = true;
 	window->windowActive = false;
 	window->windowExit = false;
-	window->lastSwapTime = GetTimeMicroseconds();
+	window->lastSwapTime = GetTimeNanoseconds();
 
 	window->app = global_app;
 	window->nativeWindow = NULL;
@@ -7231,34 +7245,34 @@ static void ksGpuWindow_SwapInterval( ksGpuWindow * window, const int swapInterv
 
 static void ksGpuWindow_SwapBuffers( ksGpuWindow * window )
 {
-	ksMicroseconds newTimeMicroseconds = ksGpuSwapchain_SwapBuffers( &window->context, &window->swapchain );
+	ksNanoseconds newTimeNanoseconds = ksGpuSwapchain_SwapBuffers( &window->context, &window->swapchain );
 
 	// Even with smoothing, this is not particularly accurate.
-	const float frameTimeMicroseconds = 1000.0f * 1000.0f / window->windowRefreshRate;
-	const float deltaTimeMicroseconds = (float)newTimeMicroseconds - window->lastSwapTime - frameTimeMicroseconds;
-	if ( fabs( deltaTimeMicroseconds ) < frameTimeMicroseconds * 0.75f )
+	const float frameTimeNanoseconds = 1000.0f * 1000.0f * 1000.0f / window->windowRefreshRate;
+	const float deltaTimeNanoseconds = (float)newTimeNanoseconds - window->lastSwapTime - frameTimeNanoseconds;
+	if ( fabs( deltaTimeNanoseconds ) < frameTimeNanoseconds * 0.75f )
 	{
-		newTimeMicroseconds = (ksMicroseconds)( window->lastSwapTime + frameTimeMicroseconds + 0.025f * deltaTimeMicroseconds );
+		newTimeNanoseconds = (ksNanoseconds)( window->lastSwapTime + frameTimeNanoseconds + 0.025f * deltaTimeNanoseconds );
 	}
-	//const float smoothDeltaMicroseconds = (float)( newTimeMicroseconds - window->lastSwapTime );
-	//Print( "frame delta = %1.3f (error = %1.3f)\n", smoothDeltaMicroseconds * ( 1.0f / 1000.0f ),
-	//					( smoothDeltaMicroseconds - frameTimeMicroseconds ) * ( 1.0f / 1000.0f ) );
-	window->lastSwapTime = newTimeMicroseconds;
+	//const float smoothDeltaNanoseconds = (float)( newTimeNanoseconds - window->lastSwapTime );
+	//Print( "frame delta = %1.3f (error = %1.3f)\n", smoothDeltaNanoseconds * 1e-6f,
+	//					( smoothDeltaNanoseconds - frameTimeNanoseconds ) * 1e-6f );
+	window->lastSwapTime = newTimeNanoseconds;
 }
 
-static ksMicroseconds ksGpuWindow_GetNextSwapTimeMicroseconds( ksGpuWindow * window )
+static ksNanoseconds ksGpuWindow_GetNextSwapTimeNanoseconds( ksGpuWindow * window )
 {
-	const float frameTimeMicroseconds = 1000.0f * 1000.0f / window->windowRefreshRate;
-	return window->lastSwapTime + (ksMicroseconds)( frameTimeMicroseconds );
+	const float frameTimeNanoseconds = 1000.0f * 1000.0f * 1000.0f / window->windowRefreshRate;
+	return window->lastSwapTime + (ksNanoseconds)( frameTimeNanoseconds );
 }
 
-static ksMicroseconds ksGpuWindow_GetFrameTimeMicroseconds( ksGpuWindow * window )
+static ksNanoseconds ksGpuWindow_GetFrameTimeNanoseconds( ksGpuWindow * window )
 {
-	const float frameTimeMicroseconds = 1000.0f * 1000.0f / window->windowRefreshRate;
-	return (ksMicroseconds)( frameTimeMicroseconds );
+	const float frameTimeNanoseconds = 1000.0f * 1000.0f * 1000.0f / window->windowRefreshRate;
+	return (ksNanoseconds)( frameTimeNanoseconds );
 }
 
-static void ksGpuWindow_DelayBeforeSwap( ksGpuWindow * window, const ksMicroseconds delay )
+static void ksGpuWindow_DelayBeforeSwap( ksGpuWindow * window, const ksNanoseconds delay )
 {
 	UNUSED_PARM( window );
 	UNUSED_PARM( delay );
@@ -7496,7 +7510,7 @@ static bool ksGpuTexture_Create2DArray( ksGpuContext * context, ksGpuTexture * t
 static bool ksGpuTexture_CreateDefault( ksGpuContext * context, ksGpuTexture * texture, const ksGpuTextureDefault defaultType,
 									const int width, const int height, const int depth,
 									const int layerCount, const int faceCount, const bool mipmaps, const bool border );
-static bool ksGpuTexture_CreateFromSwapChain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index );
+static bool ksGpuTexture_CreateFromSwapchain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index );
 static bool ksGpuTexture_CreateFromFile( ksGpuContext * context, ksGpuTexture * texture, const char * fileName );
 static void ksGpuTexture_Destroy( ksGpuContext * context, ksGpuTexture * texture );
 
@@ -8589,7 +8603,7 @@ static bool ksGpuTexture_CreateDefault( ksGpuContext * context, ksGpuTexture * t
 	return success;
 }
 
-static bool ksGpuTexture_CreateFromSwapChain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index )
+static bool ksGpuTexture_CreateFromSwapchain( ksGpuContext * context, ksGpuTexture * texture, const ksGpuWindow * window, int index )
 {
 	assert( index >= 0 && index < (int)window->swapchain.imageCount );
 
@@ -9549,7 +9563,7 @@ static bool ksGpuFramebuffer_CreateFromSwapchain( ksGpuWindow * window, ksGpuFra
 		assert( renderPass->colorFormat == window->colorFormat );
 		assert( renderPass->depthFormat == window->depthFormat );
 
-		ksGpuTexture_CreateFromSwapChain( &window->context, &framebuffer->colorTextures[imageIndex], window, imageIndex );
+		ksGpuTexture_CreateFromSwapchain( &window->context, &framebuffer->colorTextures[imageIndex], window, imageIndex );
 
 		assert( window->windowWidth == framebuffer->colorTextures[imageIndex].width );
 		assert( window->windowHeight == framebuffer->colorTextures[imageIndex].height );
@@ -10768,7 +10782,7 @@ GPU timer.
 
 A timer is used to measure the amount of time it takes to complete GPU commands.
 For optimal performance a timer should only be created at load time, not at runtime.
-To avoid synchronization, ksGpuTimer_GetMilliseconds() reports the time from GPU_TIMER_FRAMES_DELAYED frames ago.
+To avoid synchronization, ksGpuTimer_GetNanoseconds() reports the time from GPU_TIMER_FRAMES_DELAYED frames ago.
 Timer queries are allowed to overlap and can be nested.
 Timer queries that are issued inside a render pass may not produce accurate times on tiling GPUs.
 
@@ -10776,7 +10790,7 @@ ksGpuTimer
 
 static void ksGpuTimer_Create( ksGpuContext * context, ksGpuTimer * timer );
 static void ksGpuTimer_Destroy( ksGpuContext * context, ksGpuTimer * timer );
-static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer );
+static ksNanoseconds ksGpuTimer_GetNanoseconds( ksGpuTimer * timer );
 
 ================================================================================================================================
 */
@@ -10786,7 +10800,7 @@ static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer );
 typedef struct
 {
 	VkBool32			supported;
-	float				period;
+	ksNanoseconds			period;
 	VkQueryPool			pool;
 	uint32_t			init;
 	uint32_t			index;
@@ -10798,12 +10812,12 @@ static void ksGpuTimer_Create( ksGpuContext * context, ksGpuTimer * timer )
 	memset( timer, 0, sizeof( ksGpuTimer ) );
 
 	timer->supported = context->device->queueFamilyProperties[context->queueFamilyIndex].timestampValidBits != 0;
-	if (!timer->supported)
+	if ( !timer->supported )
 	{
 		return;
 	}
 
-	timer->period = context->device->physicalDeviceProperties.limits.timestampPeriod;
+	timer->period = (ksNanoseconds)context->device->physicalDeviceProperties.limits.timestampPeriod;
 
 	const uint32_t queryCount = ( GPU_TIMER_FRAMES_DELAYED + 1 ) * 2;
 
@@ -10824,18 +10838,18 @@ static void ksGpuTimer_Create( ksGpuContext * context, ksGpuTimer * timer )
 
 static void ksGpuTimer_Destroy( ksGpuContext * context, ksGpuTimer * timer )
 {
-	if (timer->supported)
+	if ( timer->supported )
 	{
 		VC( context->device->vkDestroyQueryPool( context->device->device, timer->pool, VK_ALLOCATOR ) );
 	}
 
 }
 
-static float ksGpuTimer_GetMilliseconds( ksGpuTimer * timer )
+static ksNanoseconds ksGpuTimer_GetNanoseconds( ksGpuTimer * timer )
 {
-	if (timer->supported)
+	if ( timer->supported )
 	{
-		return ( timer->data[1] - timer->data[0] ) * timer->period * ( 1.0f / 1000.0f / 1000.0f );
+		return ( timer->data[1] - timer->data[0] ) * timer->period;
 	}
 	else
 	{
@@ -12001,7 +12015,7 @@ static void ksGpuCommandBuffer_BeginTimer( ksGpuCommandBuffer * commandBuffer, k
 {
 	ksGpuDevice * device = commandBuffer->context->device;
 
-	if (!timer->supported)
+	if ( !timer->supported )
 	{
 		return;
 	}
@@ -12012,7 +12026,6 @@ static void ksGpuCommandBuffer_BeginTimer( ksGpuCommandBuffer * commandBuffer, k
 		assert( commandBuffer->currentTimers[i] != timer );
 	}
 
-
 	VC( device->vkCmdWriteTimestamp( commandBuffer->cmdBuffers[commandBuffer->currentBuffer], VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, timer->pool, timer->index * 2 + 0 ) );
 }
 
@@ -12020,7 +12033,7 @@ static void ksGpuCommandBuffer_EndTimer( ksGpuCommandBuffer * commandBuffer, ksG
 {
 	ksGpuDevice * device = commandBuffer->context->device;
 
-	if (!timer->supported)
+	if ( !timer->supported )
 	{
 		return;
 	}
@@ -13063,8 +13076,8 @@ static void ksTimeWarpBarGraphs_RenderGraphics( ksGpuCommandBuffer * commandBuff
 static void ksTimeWarpBarGraphs_UpdateCompute( ksGpuCommandBuffer * commandBuffer, ksTimeWarpBarGraphs * bargraphs );
 static void ksTimeWarpBarGraphs_RenderCompute( ksGpuCommandBuffer * commandBuffer, ksTimeWarpBarGraphs * bargraphs, ksGpuFramebuffer * framebuffer );
 
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsGraphics( ksTimeWarpBarGraphs * bargraphs );
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsCompute( ksTimeWarpBarGraphs * bargraphs );
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsGraphics( ksTimeWarpBarGraphs * bargraphs );
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsCompute( ksTimeWarpBarGraphs * bargraphs );
 
 ================================================================================================================================
 */
@@ -13106,7 +13119,7 @@ typedef struct
 {
 	ksBarGraphState	barGraphState;
 
-	ksBarGraph		eyeTexturesFrameRateGraph;
+	ksBarGraph		applicationFrameRateGraph;
 	ksBarGraph		timeWarpFrameRateGraph;
 	ksBarGraph		frameCpuTimeBarGraph;
 	ksBarGraph		frameGpuTimeBarGraph;
@@ -13128,7 +13141,7 @@ typedef struct
 
 enum
 {
-	PROFILE_TIME_EYE_TEXTURES,
+	PROFILE_TIME_APPLICATION,
 	PROFILE_TIME_TIME_WARP,
 	PROFILE_TIME_BAR_GRAPHS,
 	PROFILE_TIME_BLIT,
@@ -13156,7 +13169,7 @@ static void ksTimeWarpBarGraphs_Create( ksGpuContext * context, ksTimeWarpBarGra
 {
 	bargraphs->barGraphState = BAR_GRAPH_VISIBLE;
 
-	ksBarGraph_CreateVirtualRect( context, &bargraphs->eyeTexturesFrameRateGraph, renderPass, &eyeTextureFrameRateBarGraphRect, 64, 1, &colorDarkGrey );
+	ksBarGraph_CreateVirtualRect( context, &bargraphs->applicationFrameRateGraph, renderPass, &eyeTextureFrameRateBarGraphRect, 64, 1, &colorDarkGrey );
 	ksBarGraph_CreateVirtualRect( context, &bargraphs->timeWarpFrameRateGraph, renderPass, &timeWarpFrameRateBarGraphRect, 64, 1, &colorDarkGrey );
 	ksBarGraph_CreateVirtualRect( context, &bargraphs->frameCpuTimeBarGraph, renderPass, &frameCpuTimeBarGraphRect, 64, PROFILE_TIME_MAX, &colorDarkGrey );
 	ksBarGraph_CreateVirtualRect( context, &bargraphs->frameGpuTimeBarGraph, renderPass, &frameGpuTimeBarGraphRect, 64, PROFILE_TIME_MAX, &colorDarkGrey );
@@ -13186,7 +13199,7 @@ static void ksTimeWarpBarGraphs_Create( ksGpuContext * context, ksTimeWarpBarGra
 
 static void ksTimeWarpBarGraphs_Destroy( ksGpuContext * context, ksTimeWarpBarGraphs * bargraphs )
 {
-	ksBarGraph_Destroy( context, &bargraphs->eyeTexturesFrameRateGraph );
+	ksBarGraph_Destroy( context, &bargraphs->applicationFrameRateGraph );
 	ksBarGraph_Destroy( context, &bargraphs->timeWarpFrameRateGraph );
 	ksBarGraph_Destroy( context, &bargraphs->frameCpuTimeBarGraph );
 	ksBarGraph_Destroy( context, &bargraphs->frameGpuTimeBarGraph );
@@ -13210,7 +13223,7 @@ static void ksTimeWarpBarGraphs_UpdateGraphics( ksGpuCommandBuffer * commandBuff
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph );
+		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->applicationFrameRateGraph );
 		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->timeWarpFrameRateGraph );
 		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->frameCpuTimeBarGraph );
 		ksBarGraph_UpdateGraphics( commandBuffer, &bargraphs->frameGpuTimeBarGraph );
@@ -13235,7 +13248,7 @@ static void ksTimeWarpBarGraphs_RenderGraphics( ksGpuCommandBuffer * commandBuff
 	{
 		ksGpuCommandBuffer_BeginTimer( commandBuffer, &bargraphs->barGraphTimer );
 
-		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph );
+		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->applicationFrameRateGraph );
 		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->timeWarpFrameRateGraph );
 		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->frameCpuTimeBarGraph );
 		ksBarGraph_RenderGraphics( commandBuffer, &bargraphs->frameGpuTimeBarGraph );
@@ -13260,7 +13273,7 @@ static void ksTimeWarpBarGraphs_UpdateCompute( ksGpuCommandBuffer * commandBuffe
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph );
+		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->applicationFrameRateGraph );
 		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->timeWarpFrameRateGraph );
 		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->frameCpuTimeBarGraph );
 		ksBarGraph_UpdateCompute( commandBuffer, &bargraphs->frameGpuTimeBarGraph );
@@ -13285,7 +13298,7 @@ static void ksTimeWarpBarGraphs_RenderCompute( ksGpuCommandBuffer * commandBuffe
 	{
 		ksGpuCommandBuffer_BeginTimer( commandBuffer, &bargraphs->barGraphTimer );
 
-		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->eyeTexturesFrameRateGraph, framebuffer );
+		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->applicationFrameRateGraph, framebuffer );
 		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->timeWarpFrameRateGraph, framebuffer );
 		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->frameCpuTimeBarGraph, framebuffer );
 		ksBarGraph_RenderCompute( commandBuffer, &bargraphs->frameGpuTimeBarGraph, framebuffer );
@@ -13306,22 +13319,22 @@ static void ksTimeWarpBarGraphs_RenderCompute( ksGpuCommandBuffer * commandBuffe
 	}
 }
 
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsGraphics( ksTimeWarpBarGraphs * bargraphs )
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsGraphics( ksTimeWarpBarGraphs * bargraphs )
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		return ksGpuTimer_GetMilliseconds( &bargraphs->barGraphTimer );
+		return ksGpuTimer_GetNanoseconds( &bargraphs->barGraphTimer );
 	}
-	return 0.0f;
+	return 0;
 }
 
-static float ksTimeWarpBarGraphs_GetGpuMillisecondsCompute( ksTimeWarpBarGraphs * bargraphs )
+static ksNanoseconds ksTimeWarpBarGraphs_GetGpuNanosecondsCompute( ksTimeWarpBarGraphs * bargraphs )
 {
 	if ( bargraphs->barGraphState != BAR_GRAPH_HIDDEN )
 	{
-		return ksGpuTimer_GetMilliseconds( &bargraphs->barGraphTimer );
+		return ksGpuTimer_GetNanoseconds( &bargraphs->barGraphTimer );
 	}
-	return 0.0f;
+	return 0;
 }
 
 /*
@@ -13405,7 +13418,7 @@ static const ksBodyInfo * GetDefaultBodyInfo()
 
 static bool hmd_headRotationDisabled = false;
 
-static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksMicroseconds time )
+static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksNanoseconds time )
 {
 	if ( hmd_headRotationDisabled )
 	{
@@ -13413,7 +13426,7 @@ static void GetHmdViewMatrixForTime( ksMatrix4x4f * viewMatrix, const ksMicrosec
 		return;
 	}
 
-	const float offset = time * ( MATH_PI / 1000.0f / 1000.0f );
+	const float offset = time * ( MATH_PI / 1000.0f / 1000.0f / 1000.0f );
 	const float degrees = 10.0f;
 	const float degreesX = sinf( offset ) * degrees;
 	const float degreesY = cosf( offset ) * degrees;
@@ -13582,11 +13595,11 @@ static void ksTimeWarpGraphics_Create( ksGpuContext * context, ksTimeWarpGraphic
 static void ksTimeWarpGraphics_Destroy( ksGpuContext * context, ksTimeWarpGraphics * graphics );
 static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpGraphics * graphics,
 									ksGpuFramebuffer * framebuffer, ksGpuRenderPass * renderPass,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] );
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] );
 
 ================================================================================================================================
 */
@@ -14149,13 +14162,13 @@ static void ksTimeWarpGraphics_Destroy( ksGpuContext * context, ksTimeWarpGraphi
 
 static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpGraphics * graphics,
 									ksGpuFramebuffer * framebuffer, ksGpuRenderPass * renderPass,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] )
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] )
 {
-	const ksMicroseconds t0 = GetTimeMicroseconds();
+	const ksNanoseconds t0 = GetTimeNanoseconds();
 
 	ksMatrix4x4f displayRefreshStartViewMatrix;
 	ksMatrix4x4f displayRefreshEndViewMatrix;
@@ -14198,7 +14211,7 @@ static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTim
 		ksGpuCommandBuffer_SubmitGraphicsCommand( commandBuffer, &command );
 	}
 
-	const ksMicroseconds t1 = GetTimeMicroseconds();
+	const ksNanoseconds t1 = GetTimeNanoseconds();
 
 	ksTimeWarpBarGraphs_RenderGraphics( commandBuffer, bargraphs );
 
@@ -14210,17 +14223,17 @@ static void ksTimeWarpGraphics_Render( ksGpuCommandBuffer * commandBuffer, ksTim
 
 	ksGpuCommandBuffer_SubmitPrimary( commandBuffer );
 
-	const ksMicroseconds t2 = GetTimeMicroseconds();
+	const ksNanoseconds t2 = GetTimeNanoseconds();
 
-	cpuTimes[PROFILE_TIME_TIME_WARP] = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = ( t2 - t1 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	cpuTimes[PROFILE_TIME_TIME_WARP] = t1 - t0;
+	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = t2 - t1;
+	cpuTimes[PROFILE_TIME_BLIT] = 0;
 
-	const float barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuMillisecondsGraphics( bargraphs );
+	const ksNanoseconds barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuNanosecondsGraphics( bargraphs );
 
-	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetMilliseconds( &graphics->timeWarpGpuTime ) - barGraphGpuTime;
+	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetNanoseconds( &graphics->timeWarpGpuTime ) - barGraphGpuTime;
 	gpuTimes[PROFILE_TIME_BAR_GRAPHS] = barGraphGpuTime;
-	gpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	gpuTimes[PROFILE_TIME_BLIT] = 0;
 }
 
 /*
@@ -14235,11 +14248,11 @@ static void ksTimeWarpCompute_Create( ksGpuContext * context, ksTimeWarpCompute 
 static void ksTimeWarpCompute_Destroy( ksGpuContext * context, ksTimeWarpCompute * compute );
 static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpCompute * compute,
 									ksGpuFramebuffer * framebuffer,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] );
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] );
 
 ================================================================================================================================
 */
@@ -14811,13 +14824,13 @@ static void ksTimeWarpCompute_Destroy( ksGpuContext * context, ksTimeWarpCompute
 
 static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTimeWarpCompute * compute,
 									ksGpuFramebuffer * framebuffer,
-									const ksMicroseconds refreshStartTime, const ksMicroseconds refreshEndTime,
+									const ksNanoseconds refreshStartTime, const ksNanoseconds refreshEndTime,
 									const ksMatrix4x4f * projectionMatrix, const ksMatrix4x4f * viewMatrix,
 									ksGpuTexture * const eyeTexture[NUM_EYES], const int eyeArrayLayer[NUM_EYES],
 									const bool correctChromaticAberration, ksTimeWarpBarGraphs * bargraphs,
-									float cpuTimes[PROFILE_TIME_MAX], float gpuTimes[PROFILE_TIME_MAX] )
+									ksNanoseconds cpuTimes[PROFILE_TIME_MAX], ksNanoseconds gpuTimes[PROFILE_TIME_MAX] )
 {
-	const ksMicroseconds t0 = GetTimeMicroseconds();
+	const ksNanoseconds t0 = GetTimeNanoseconds();
 
 	ksMatrix4x4f displayRefreshStartViewMatrix;
 	ksMatrix4x4f displayRefreshEndViewMatrix;
@@ -14927,7 +14940,7 @@ static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTime
 		ksGpuCommandBuffer_SubmitComputeCommand( commandBuffer, &command );
 	}
 
-	const ksMicroseconds t1 = GetTimeMicroseconds();
+	const ksNanoseconds t1 = GetTimeNanoseconds();
 
 	ksTimeWarpBarGraphs_UpdateCompute( commandBuffer, bargraphs );
 	ksTimeWarpBarGraphs_RenderCompute( commandBuffer, bargraphs, framebuffer );
@@ -14939,17 +14952,17 @@ static void ksTimeWarpCompute_Render( ksGpuCommandBuffer * commandBuffer, ksTime
 
 	ksGpuCommandBuffer_SubmitPrimary( commandBuffer );
 
-	const ksMicroseconds t2 = GetTimeMicroseconds();
+	const ksNanoseconds t2 = GetTimeNanoseconds();
 
-	cpuTimes[PROFILE_TIME_TIME_WARP] = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = ( t2 - t1 ) * ( 1.0f / 1000.0f );
-	cpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	cpuTimes[PROFILE_TIME_TIME_WARP] = t1 - t0;
+	cpuTimes[PROFILE_TIME_BAR_GRAPHS] = t2 - t1;
+	cpuTimes[PROFILE_TIME_BLIT] = 0;
 
-	const float barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuMillisecondsCompute( bargraphs );
+	const ksNanoseconds barGraphGpuTime = ksTimeWarpBarGraphs_GetGpuNanosecondsCompute( bargraphs );
 
-	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetMilliseconds( &compute->timeWarpGpuTime ) - barGraphGpuTime;
+	gpuTimes[PROFILE_TIME_TIME_WARP] = ksGpuTimer_GetNanoseconds( &compute->timeWarpGpuTime ) - barGraphGpuTime;
 	gpuTimes[PROFILE_TIME_BAR_GRAPHS] = barGraphGpuTime;
-	gpuTimes[PROFILE_TIME_BLIT] = 0.0f;
+	gpuTimes[PROFILE_TIME_BLIT] = 0;
 }
 
 /*
@@ -14979,11 +14992,11 @@ static void ksTimeWarp_SetDrawCallLevel( ksTimeWarp * timeWarp, const int level 
 static void ksTimeWarp_SetTriangleLevel( ksTimeWarp * timeWarp, const int level );
 static void ksTimeWarp_SetFragmentLevel( ksTimeWarp * timeWarp, const int level );
 
-static ksMicroseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex );
-static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksMicroseconds displayTime,
+static ksNanoseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex );
+static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksNanoseconds displayTime,
 									const ksMatrix4x4f * viewMatrix, const Matrix4x4_t * projectionMatrix,
 									ksGpuTexture * eyeTexture[NUM_EYES], ksGpuFence * eyeCompletionFence[NUM_EYES],
-									int eyeArrayLayer[NUM_EYES], float eyeTexturesCpuTime, float eyeTexturesGpuTime );
+									int eyeArrayLayer[NUM_EYES], ksNanoseconds eyeTexturesCpuTime, ksNanoseconds eyeTexturesGpuTime );
 static void ksTimeWarp_Render( ksTimeWarp * timeWarp );
 
 ================================================================================================================================
@@ -15002,28 +15015,28 @@ typedef struct
 {
 	int							index;
 	int							frameIndex;
-	ksMicroseconds				displayTime;
+	ksNanoseconds				displayTime;
 	ksMatrix4x4f				viewMatrix;
 	ksMatrix4x4f				projectionMatrix;
 	ksGpuTexture *				texture[NUM_EYES];
 	ksGpuFence *				completionFence[NUM_EYES];
 	int							arrayLayer[NUM_EYES];
-	float						cpuTime;
-	float						gpuTime;
+	ksNanoseconds				cpuTime;
+	ksNanoseconds				gpuTime;
 } ksEyeTextures;
 
 typedef struct
 {
 	long long					frameIndex;
-	ksMicroseconds				vsyncTime;
-	ksMicroseconds				frameTime;
+	ksNanoseconds				vsyncTime;
+	ksNanoseconds				frameTime;
 } ksFrameTiming;
 
 typedef struct
 {
 	ksGpuWindow *				window;
 	ksGpuTexture				defaultTexture;
-	ksMicroseconds				displayTime;
+	ksNanoseconds				displayTime;
 	ksMatrix4x4f				viewMatrix;
 	ksMatrix4x4f				projectionMatrix;
 	ksGpuTexture *				eyeTexture[NUM_EYES];
@@ -15040,11 +15053,11 @@ typedef struct
 	ksSignal					vsyncSignal;
 
 	float						refreshRate;
-	ksMicroseconds				frameCpuTime[AVERAGE_FRAME_RATE_FRAMES];
+	ksNanoseconds				frameCpuTime[AVERAGE_FRAME_RATE_FRAMES];
 	int							eyeTexturesFrames[AVERAGE_FRAME_RATE_FRAMES];
 	int							timeWarpFrames;
-	float						cpuTimes[PROFILE_TIME_MAX];
-	float						gpuTimes[PROFILE_TIME_MAX];
+	ksNanoseconds				cpuTimes[PROFILE_TIME_MAX];
+	ksNanoseconds				gpuTimes[PROFILE_TIME_MAX];
 
 	ksGpuRenderPass				renderPass;
 	ksGpuFramebuffer			framebuffer;
@@ -15070,15 +15083,15 @@ static void ksTimeWarp_Create( ksTimeWarp * timeWarp, ksGpuWindow * window )
 	timeWarp->newEyeTextures.index = 0;
 	timeWarp->newEyeTextures.displayTime = 0;
 	ksMatrix4x4f_CreateIdentity( &timeWarp->newEyeTextures.viewMatrix );
-	ksMatrix4x4f_CreateProjectionFov( &timeWarp->newEyeTextures.projectionMatrix, 80.0f, 80.0f, 0.0f, 0.0f, 0.1f, 0.0f );
+	ksMatrix4x4f_CreateProjectionFov( &timeWarp->newEyeTextures.projectionMatrix, 40.0f, 40.0f, 40.0f, 40.0f, 0.1f, 0.0f );
 	for ( int eye = 0; eye < NUM_EYES; eye++ )
 	{
 		timeWarp->newEyeTextures.texture[eye] = &timeWarp->defaultTexture;
 		timeWarp->newEyeTextures.completionFence[eye] = NULL;
 		timeWarp->newEyeTextures.arrayLayer[eye] = eye;
 	}
-	timeWarp->newEyeTextures.cpuTime = 0.0f;
-	timeWarp->newEyeTextures.gpuTime = 0.0f;
+	timeWarp->newEyeTextures.cpuTime = 0;
+	timeWarp->newEyeTextures.gpuTime = 0;
 
 	timeWarp->displayTime = 0;
 	timeWarp->viewMatrix = timeWarp->newEyeTextures.viewMatrix;
@@ -15240,7 +15253,7 @@ static void ksTimeWarp_SetFragmentLevel( ksTimeWarp * timeWarp, const int level 
 	}
 }
 
-static ksMicroseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex )
+static ksNanoseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp, const int frameIndex )
 {
 	ksMutex_Lock( &timeWarp->frameTimingMutex, true );
 	const ksFrameTiming frameTiming = timeWarp->frameTiming;
@@ -15248,18 +15261,19 @@ static ksMicroseconds ksTimeWarp_GetPredictedDisplayTime( ksTimeWarp * timeWarp,
 
 	// The time warp thread is currently released by SwapBuffers shortly after a V-Sync.
 	// Where possible, the time warp thread then waits until a short time before the next V-Sync,
-	// giving it just enough time to warp the latest eye textures onto the display. The time warp
-	// thread then tries to pick up the latest completed eye textures and warps them onto the
-	// display. The main thread is released right after the V-Sync and can start working on new
-	// eye textures that will be displayed effectively 2 display refresh cycles in the future.
+	// giving it just enough time to warp the last completed application frame onto the display.
+	// The time warp thread then tries to pick up the latest completed application frame and warps
+	// the frame onto the display. The application thread is released right after the V-Sync
+	// and can start working on a new frame that will be displayed effectively 2 display refresh
+	// cycles in the future.
 
 	return frameTiming.vsyncTime + ( frameIndex - frameTiming.frameIndex ) * frameTiming.frameTime;
 }
 
-static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksMicroseconds displayTime,
+static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex, const ksNanoseconds displayTime,
 									const ksMatrix4x4f * viewMatrix, const ksMatrix4x4f * projectionMatrix,
 									ksGpuTexture * eyeTexture[NUM_EYES], ksGpuFence * eyeCompletionFence[NUM_EYES],
-									int eyeArrayLayer[NUM_EYES], float eyeTexturesCpuTime, float eyeTexturesGpuTime )
+									int eyeArrayLayer[NUM_EYES], ksNanoseconds eyeTexturesCpuTime, ksNanoseconds eyeTexturesGpuTime )
 {
 	ksEyeTextures newEyeTextures;
 	newEyeTextures.index = timeWarp->eyeTexturesPresentIndex++;
@@ -15288,8 +15302,8 @@ static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex,
 
 	ksFrameTiming newFrameTiming;
 	newFrameTiming.frameIndex = frameIndex;
-	newFrameTiming.vsyncTime = ksGpuWindow_GetNextSwapTimeMicroseconds( timeWarp->window );
-	newFrameTiming.frameTime = ksGpuWindow_GetFrameTimeMicroseconds( timeWarp->window );
+	newFrameTiming.vsyncTime = ksGpuWindow_GetNextSwapTimeNanoseconds( timeWarp->window );
+	newFrameTiming.frameTime = ksGpuWindow_GetFrameTimeNanoseconds( timeWarp->window );
 
 	ksMutex_Lock( &timeWarp->frameTimingMutex, true );
 	timeWarp->frameTiming = newFrameTiming;
@@ -15298,8 +15312,8 @@ static void ksTimeWarp_SubmitFrame( ksTimeWarp * timeWarp, const int frameIndex,
 
 static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 {
-	const ksMicroseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeMicroseconds( timeWarp->window );
-	const ksMicroseconds frameTime = ksGpuWindow_GetFrameTimeMicroseconds( timeWarp->window );
+	const ksNanoseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeNanoseconds( timeWarp->window );
+	const ksNanoseconds frameTime = ksGpuWindow_GetFrameTimeNanoseconds( timeWarp->window );
 
 	// Wait until close to the next V-Sync but still far enough away to allow the time warp to complete rendering.
 	ksGpuWindow_DelayBeforeSwap( timeWarp->window, frameTime / 2 );
@@ -15332,8 +15346,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 				timeWarp->eyeTexture[eye] = newEyeTextures.texture[eye];
 				timeWarp->eyeArrayLayer[eye] = newEyeTextures.arrayLayer[eye];
 			}
-			timeWarp->cpuTimes[PROFILE_TIME_EYE_TEXTURES] = newEyeTextures.cpuTime;
-			timeWarp->gpuTimes[PROFILE_TIME_EYE_TEXTURES] = newEyeTextures.gpuTime;
+			timeWarp->cpuTimes[PROFILE_TIME_APPLICATION] = newEyeTextures.cpuTime;
+			timeWarp->gpuTimes[PROFILE_TIME_APPLICATION] = newEyeTextures.gpuTime;
 			timeWarp->eyeTexturesFrames[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES] = 1;
 			ksSignal_Clear( &timeWarp->vsyncSignal );
 			ksSignal_Raise( &timeWarp->newEyeTexturesConsumed );
@@ -15344,8 +15358,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 	float timeWarpFrameRate = timeWarp->refreshRate;
 	float eyeTexturesFrameRate = timeWarp->refreshRate;
 	{
-		ksMicroseconds lastTime = timeWarp->frameCpuTime[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES];
-		ksMicroseconds time = nextSwapTime;
+		ksNanoseconds lastTime = timeWarp->frameCpuTime[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES];
+		ksNanoseconds time = nextSwapTime;
 		timeWarp->frameCpuTime[timeWarp->timeWarpFrames % AVERAGE_FRAME_RATE_FRAMES] = time;
 		timeWarp->timeWarpFrames++;
 		if ( timeWarp->timeWarpFrames > AVERAGE_FRAME_RATE_FRAMES )
@@ -15357,28 +15371,28 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 				eyeTexturesFrames += timeWarp->eyeTexturesFrames[i];
 			}
 
-			timeWarpFrameRate = timeWarpFrames * 1000.0f * 1000.0f / ( time - lastTime );
-			eyeTexturesFrameRate = eyeTexturesFrames * 1000.0f * 1000.0f / ( time - lastTime );
+			timeWarpFrameRate = timeWarpFrames * 1e9f / ( time - lastTime );
+			eyeTexturesFrameRate = eyeTexturesFrames * 1e9f / ( time - lastTime );
 		}
 	}
 
 	// Update the bar graphs if not paused.
 	if ( timeWarp->bargraphs.barGraphState == BAR_GRAPH_VISIBLE )
 	{
-		const ksVector4f * eyeTexturesFrameRateColor = ( eyeTexturesFrameRate > timeWarp->refreshRate - 0.5f ) ? &colorPurple : &colorRed;
+		const ksVector4f * applicationFrameRateColor = ( eyeTexturesFrameRate > timeWarp->refreshRate - 0.5f ) ? &colorPurple : &colorRed;
 		const ksVector4f * timeWarpFrameRateColor = ( timeWarpFrameRate > timeWarp->refreshRate - 0.5f ) ? &colorGreen : &colorRed;
 
-		ksBarGraph_AddBar( &timeWarp->bargraphs.eyeTexturesFrameRateGraph, 0, eyeTexturesFrameRate / timeWarp->refreshRate, eyeTexturesFrameRateColor, true );
+		ksBarGraph_AddBar( &timeWarp->bargraphs.applicationFrameRateGraph, 0, eyeTexturesFrameRate / timeWarp->refreshRate, applicationFrameRateColor, true );
 		ksBarGraph_AddBar( &timeWarp->bargraphs.timeWarpFrameRateGraph, 0, timeWarpFrameRate / timeWarp->refreshRate, timeWarpFrameRateColor, true );
 
 		for ( int i = 0; i < 2; i++ )
 		{
-			const float * times = ( i == 0 ) ? timeWarp->cpuTimes : timeWarp->gpuTimes;
+			const ksNanoseconds * times = ( i == 0 ) ? timeWarp->cpuTimes : timeWarp->gpuTimes;
 			float barHeights[PROFILE_TIME_MAX];
 			float totalBarHeight = 0.0f;
 			for ( int p = 0; p < PROFILE_TIME_MAX; p++ )
 			{
-				barHeights[p] = times[p] * timeWarp->refreshRate * ( 1.0f / 1000.0f );
+				barHeights[p] = times[p] * timeWarp->refreshRate * 1e-9f;
 				totalBarHeight += barHeights[p];
 			}
 
@@ -15405,8 +15419,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 	ksFrameLog_BeginFrame();
 
 	//assert( timeWarp->displayTime == nextSwapTime );
-	const ksMicroseconds refreshStartTime = nextSwapTime;
-	const ksMicroseconds refreshEndTime = refreshStartTime /* + display refresh time for an incremental display refresh */;
+	const ksNanoseconds refreshStartTime = nextSwapTime;
+	const ksNanoseconds refreshEndTime = refreshStartTime /* + display refresh time for an incremental display refresh */;
 
 	if ( timeWarp->implementation == TIMEWARP_IMPLEMENTATION_GRAPHICS )
 	{
@@ -15425,14 +15439,12 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 								&timeWarp->bargraphs, timeWarp->cpuTimes, timeWarp->gpuTimes );
 	}
 
-	const int gpuTimeFramesDelayed = ( timeWarp->implementation == TIMEWARP_IMPLEMENTATION_GRAPHICS ) ? GPU_TIMER_FRAMES_DELAYED : 0;
-
 	ksFrameLog_EndFrame(	timeWarp->cpuTimes[PROFILE_TIME_TIME_WARP] +
-						timeWarp->cpuTimes[PROFILE_TIME_BAR_GRAPHS] +
-						timeWarp->cpuTimes[PROFILE_TIME_BLIT],
-						timeWarp->gpuTimes[PROFILE_TIME_TIME_WARP] +
-						timeWarp->gpuTimes[PROFILE_TIME_BAR_GRAPHS] +
-						timeWarp->gpuTimes[PROFILE_TIME_BLIT], gpuTimeFramesDelayed );
+							timeWarp->cpuTimes[PROFILE_TIME_BAR_GRAPHS] +
+							timeWarp->cpuTimes[PROFILE_TIME_BLIT],
+							timeWarp->gpuTimes[PROFILE_TIME_TIME_WARP] +
+							timeWarp->gpuTimes[PROFILE_TIME_BAR_GRAPHS] +
+							timeWarp->gpuTimes[PROFILE_TIME_BLIT], GPU_TIMER_FRAMES_DELAYED );
 
 	ksGpuWindow_SwapBuffers( timeWarp->window );
 
@@ -15445,8 +15457,8 @@ static void ksTimeWarp_Render( ksTimeWarp * timeWarp )
 ksViewState
 
 static void ksViewState_Init( ksViewState * viewState, const float interpupillaryDistance );
-static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time );
-static void ksViewState_HandleHmd( ksViewState * viewState, const ksMicroseconds time );
+static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time );
+static void ksViewState_HandleHmd( ksViewState * viewState, const ksNanoseconds time );
 
 ================================================================================================================================
 */
@@ -15517,7 +15529,7 @@ static void ksViewState_Init( ksViewState * viewState, const float interpupillar
 	for ( int eye = 0; eye < NUM_EYES; eye++ )
 	{
 		ksMatrix4x4f_CreateIdentity( &viewState->viewMatrix[eye] );
-		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 90.0f, 60.0f, 0.0f, 0.0f, 0.01f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 45.0f, 45.0f, 30.0f, 30.0f, DEFAULT_NEAR_Z, 0.0f );
 
 		ksMatrix4x4f_Invert( &viewState->viewInverseMatrix[eye], &viewState->viewMatrix[eye] );
 		ksMatrix4x4f_Invert( &viewState->projectionInverseMatrix[eye], &viewState->projectionMatrix[eye] );
@@ -15526,7 +15538,7 @@ static void ksViewState_Init( ksViewState * viewState, const float interpupillar
 	ksViewState_DerivedData( viewState );
 }
 
-static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time )
+static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time )
 {
 	static const float TRANSLATION_UNITS_PER_TAP		= 0.005f;
 	static const float TRANSLATION_UNITS_DECAY			= 0.0025f;
@@ -15607,13 +15619,13 @@ static void ksViewState_HandleInput( ksViewState * viewState, ksGpuWindowInput *
 		ksMatrix4x4f_CreateTranslation( &eyeOffsetMatrix, ( eye ? -0.5f : 0.5f ) * viewState->interpupillaryDistance, 0.0f, 0.0f );
 
 		ksMatrix4x4f_Multiply( &viewState->viewMatrix[eye], &eyeOffsetMatrix, &viewState->centerViewMatrix );
-		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 90.0f, 60.0f, 0.0f, 0.0f, 0.01f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 45.0f, 45.0f, 30.0f, 30.0f, DEFAULT_NEAR_Z, 0.0f );
 	}
 
 	ksViewState_DerivedData( viewState );
 }
 
-static void ksViewState_HandleHmd( ksViewState * viewState, const ksMicroseconds time )
+static void ksViewState_HandleHmd( ksViewState * viewState, const ksNanoseconds time )
 {
 	GetHmdViewMatrixForTime( &viewState->hmdViewMatrix, time );
 
@@ -15625,7 +15637,7 @@ static void ksViewState_HandleHmd( ksViewState * viewState, const ksMicroseconds
 		ksMatrix4x4f_CreateTranslation( &eyeOffsetMatrix, ( eye ? -0.5f : 0.5f ) * viewState->interpupillaryDistance, 0.0f, 0.0f );
 
 		ksMatrix4x4f_Multiply( &viewState->viewMatrix[eye], &eyeOffsetMatrix, &viewState->centerViewMatrix );
-		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 90.0f, 72.0f, 0.0f, 0.0f, 0.01f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye], 45.0f, 45.0f, 36.0f, 36.0f, DEFAULT_NEAR_Z, 0.0f );
 	}
 
 	ksViewState_DerivedData( viewState );
@@ -15791,7 +15803,7 @@ ksPerfScene
 
 static void ksPerfScene_Create( ksGpuContext * context, ksPerfScene * scene, ksSceneSettings * settings, ksGpuRenderPass * renderPass );
 static void ksPerfScene_Destroy( ksGpuContext * context, ksPerfScene * scene );
-static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksMicroseconds time );
+static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksNanoseconds time );
 static void ksPerfScene_UpdateBuffers( ksGpuCommandBuffer * commandBuffer, ksPerfScene * scene, ksViewState * viewState, const int eye );
 static void ksPerfScene_Render( ksGpuCommandBuffer * commandBuffer, ksPerfScene * scene );
 
@@ -17017,7 +17029,7 @@ static void ksPerfScene_Destroy( ksGpuContext * context, ksPerfScene * scene )
 	scene->modelMatrix = NULL;
 }
 
-static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksMicroseconds time )
+static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, const ksNanoseconds time )
 {
 	// Must recreate the scene if multi-view is enabled/disabled.
 	assert( scene->settings.useMultiView == scene->newSettings->useMultiView );
@@ -17027,7 +17039,8 @@ static void ksPerfScene_Simulate( ksPerfScene * scene, ksViewState * viewState, 
 
 	if ( !scene->settings.simulationPaused )
 	{
-		const float offset = time * ( MATH_PI / 1000.0f / 1000.0f );
+		// FIXME: use double?
+		const float offset = time * ( MATH_PI / 1000.0f / 1000.0f / 1000.0f );
 		scene->bigRotationX = 20.0f * offset;
 		scene->bigRotationY = 10.0f * offset;
 		scene->smallRotationX = -60.0f * offset;
@@ -17105,7 +17118,7 @@ ksGltfScene
 
 static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * scene, const char * fileName, ksGpuRenderPass * renderPass );
 static void ksGltfScene_Destroy( ksGpuContext * context, ksGltfScene * scene );
-static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time );
+static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time );
 static void ksGltfScene_UpdateBuffers( ksGpuCommandBuffer * commandBuffer, const ksGltfScene * scene, const ksViewState * viewState, const int eye );
 static void ksGltfScene_Render( ksGpuCommandBuffer * commandBuffer, const ksGltfScene * scene, const ksViewState * viewState, const int eye );
 
@@ -18211,7 +18224,7 @@ static void ksGltf_SortNodes( ksGltfNode * nodes, const int nodeCount )
 
 static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * scene, const char * fileName, ksGpuRenderPass * renderPass )
 {
-	const ksMicroseconds t0 = GetTimeMicroseconds();
+	const ksNanoseconds t0 = GetTimeNanoseconds();
 
 	memset( scene, 0, sizeof( ksGltfScene ) );
 
@@ -18233,7 +18246,7 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 		// glTF buffers
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * buffers = Json_GetMemberByName( rootNode, "buffers" );
 			scene->bufferCount = Json_GetMemberCount( buffers );
@@ -18251,15 +18264,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateBufferNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load buffers\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load buffers\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF bufferViews
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * bufferViews = Json_GetMemberByName( rootNode, "bufferViews" );
 			scene->bufferViewCount = Json_GetMemberCount( bufferViews );
@@ -18279,15 +18292,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateBufferViewNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load buffer views\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load buffer views\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF accessors
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * accessors = Json_GetMemberByName( rootNode, "accessors" );
 			scene->accessorCount = Json_GetMemberCount( accessors );
@@ -18340,15 +18353,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateAccessorNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load accessors\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load accessors\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF images
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * images = Json_GetMemberByName( rootNode, "images" );
 			scene->imageCount = Json_GetMemberCount( images );
@@ -18363,15 +18376,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateImageNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load images\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load images\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF samplers
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * samplers = Json_GetMemberByName( rootNode, "samplers" );
 			scene->samplerCount = Json_GetMemberCount( samplers );
@@ -18388,15 +18401,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateSamplerNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load samplers\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load samplers\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF textures
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * textures = Json_GetMemberByName( rootNode, "textures" );
 			scene->textureCount = Json_GetMemberCount( textures );
@@ -18420,15 +18433,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateTextureNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load textures\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load textures\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF shaders
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * shaders = Json_GetMemberByName( rootNode, "shaders" );
 			scene->shaderCount = Json_GetMemberCount( shaders );
@@ -18451,15 +18464,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateShaderNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load shaders\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load shaders\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF programs
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * programs = Json_GetMemberByName( rootNode, "programs" );
 			scene->programCount = Json_GetMemberCount( programs );
@@ -18489,15 +18502,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateProgramNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load programs\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load programs\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF techniques
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * techniques = Json_GetMemberByName( rootNode, "techniques" );
 			scene->techniqueCount = Json_GetMemberCount( techniques );
@@ -18749,15 +18762,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateTechniqueNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load techniques\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load techniques\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF materials
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * materials = Json_GetMemberByName( rootNode, "materials" );
 			scene->materialCount = Json_GetMemberCount( materials );
@@ -18817,15 +18830,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateMaterialNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load materials\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load materials\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF meshes
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * models = Json_GetMemberByName( rootNode, "meshes" );
 			scene->modelCount = Json_GetMemberCount( models );
@@ -18863,10 +18876,10 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 					assert( surface->material != NULL );
 
 					const ksGltfAccessor * positionAccessor		= ksGltf_GetAccessorByNameAndType( scene, positionAccessorName,		"VEC3",		GL_FLOAT );
-					const ksGltfAccessor * normalAccessor		= ksGltf_GetAccessorByNameAndType( scene, normalAccessorName,			"VEC3",		GL_FLOAT );
+					const ksGltfAccessor * normalAccessor		= ksGltf_GetAccessorByNameAndType( scene, normalAccessorName,		"VEC3",		GL_FLOAT );
 					const ksGltfAccessor * tangentAccessor		= ksGltf_GetAccessorByNameAndType( scene, tangentAccessorName,		"VEC3",		GL_FLOAT );
 					const ksGltfAccessor * binormalAccessor		= ksGltf_GetAccessorByNameAndType( scene, binormalAccessorName,		"VEC3",		GL_FLOAT );
-					const ksGltfAccessor * colorAccessor		= ksGltf_GetAccessorByNameAndType( scene, colorAccessorName,			"VEC4",		GL_FLOAT );
+					const ksGltfAccessor * colorAccessor		= ksGltf_GetAccessorByNameAndType( scene, colorAccessorName,		"VEC4",		GL_FLOAT );
 					const ksGltfAccessor * uv0Accessor			= ksGltf_GetAccessorByNameAndType( scene, uv0AccessorName,			"VEC2",		GL_FLOAT );
 					const ksGltfAccessor * uv1Accessor			= ksGltf_GetAccessorByNameAndType( scene, uv1AccessorName,			"VEC2",		GL_FLOAT );
 					const ksGltfAccessor * uv2Accessor			= ksGltf_GetAccessorByNameAndType( scene, uv2AccessorName,			"VEC2",		GL_FLOAT );
@@ -18912,10 +18925,10 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 					ksGpuVertexAttributeArrays_Alloc( &attribs.base, DefaultVertexAttributeLayout, positionAccessor->count, attribFlags );
 
 					if ( positionAccessor != NULL )		memcpy( attribs.position,		ksGltf_GetBufferData( positionAccessor ),		positionAccessor->count		* sizeof( attribs.position[0] ) );
-					if ( normalAccessor != NULL )		memcpy( attribs.normal,			ksGltf_GetBufferData( normalAccessor ),		normalAccessor->count		* sizeof( attribs.normal[0] ) );
+					if ( normalAccessor != NULL )		memcpy( attribs.normal,			ksGltf_GetBufferData( normalAccessor ),			normalAccessor->count		* sizeof( attribs.normal[0] ) );
 					if ( tangentAccessor != NULL )		memcpy( attribs.tangent,		ksGltf_GetBufferData( tangentAccessor ),		tangentAccessor->count		* sizeof( attribs.tangent[0] ) );
 					if ( binormalAccessor != NULL )		memcpy( attribs.binormal,		ksGltf_GetBufferData( binormalAccessor ),		binormalAccessor->count		* sizeof( attribs.binormal[0] ) );
-					if ( colorAccessor != NULL )		memcpy( attribs.color,			ksGltf_GetBufferData( colorAccessor ),		colorAccessor->count		* sizeof( attribs.color[0] ) );
+					if ( colorAccessor != NULL )		memcpy( attribs.color,			ksGltf_GetBufferData( colorAccessor ),			colorAccessor->count		* sizeof( attribs.color[0] ) );
 					if ( uv0Accessor != NULL )			memcpy( attribs.uv0,			ksGltf_GetBufferData( uv0Accessor ),			uv0Accessor->count			* sizeof( attribs.uv0[0] ) );
 					if ( uv1Accessor != NULL )			memcpy( attribs.uv1,			ksGltf_GetBufferData( uv1Accessor ),			uv1Accessor->count			* sizeof( attribs.uv1[0] ) );
 					if ( uv2Accessor != NULL )			memcpy( attribs.uv2,			ksGltf_GetBufferData( uv2Accessor ),			uv2Accessor->count			* sizeof( attribs.uv2[0] ) );
@@ -18941,15 +18954,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateModelNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load models\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load models\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF animations
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * animations = Json_GetMemberByName( rootNode, "animations" );
 			scene->animationCount = Json_GetMemberCount( animations );
@@ -19062,15 +19075,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateAnimationNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load animations\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load animations\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF skins
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * skins = Json_GetMemberByName( rootNode, "skins" );
 			scene->skinCount = Json_GetMemberCount( skins );
@@ -19111,15 +19124,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateSkinNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load skins\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load skins\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF cameras
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * cameras = Json_GetMemberByName( rootNode, "cameras" );
 			scene->cameraCount = Json_GetMemberCount( cameras );
@@ -19158,15 +19171,15 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			}
 			ksGltf_CreateCameraNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load cameras\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load cameras\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
 		// glTF nodes
 		//
 		{
-			const ksMicroseconds startTime = GetTimeMicroseconds();
+			const ksNanoseconds startTime = GetTimeNanoseconds();
 
 			const Json_t * nodes = Json_GetMemberByName( rootNode, "nodes" );
 			scene->nodeCount = Json_GetMemberCount( nodes );
@@ -19222,8 +19235,8 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 			ksGltf_CreateNodeNameHash( scene );
 			ksGltf_CreateNodeJointNameHash( scene );
 
-			const ksMicroseconds endTime = GetTimeMicroseconds();
-			Print( "%1.3f seconds to load nodes\n", ( endTime - startTime ) * 1e-6f );
+			const ksNanoseconds endTime = GetTimeNanoseconds();
+			Print( "%1.3f seconds to load nodes\n", ( endTime - startTime ) * 1e-9f );
 		}
 
 		//
@@ -19343,9 +19356,9 @@ static bool ksGltfScene_CreateFromFile( ksGpuContext * context, ksGltfScene * sc
 		ksGpuGraphicsPipeline_Create( context, &scene->unitCubePipeline, &pipelineParms );
 	}
 
-	const ksMicroseconds t1 = GetTimeMicroseconds();
+	const ksNanoseconds t1 = GetTimeNanoseconds();
 
-	Print( "%1.3f seconds to load %s\n", ( t1 - t0 ) * 1e-6f, fileName );
+	Print( "%1.3f seconds to load %s\n", ( t1 - t0 ) * 1e-9f, fileName );
 
 	return true;
 }
@@ -19529,7 +19542,7 @@ static void ksGltfScene_Destroy( ksGpuContext * context, ksGltfScene * scene )
 	memset( scene, 0, sizeof( ksGltfScene ) );
 }
 
-static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksMicroseconds time )
+static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, ksGpuWindowInput * input, const ksNanoseconds time )
 {
 	// Apply animations to the nodes in the hierarchy.
 	for ( int animIndex = 0; animIndex < scene->animationCount; animIndex++ )
@@ -19540,7 +19553,7 @@ static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, 
 			continue;
 		}
 
-		const float timeInSeconds = fmodf( time * 1e-6f, animation->sampleTimes[animation->sampleCount - 1] - animation->sampleTimes[0] );
+		const float timeInSeconds = fmodf( time * 1e-9f, animation->sampleTimes[animation->sampleCount - 1] - animation->sampleTimes[0] );
 		int frame = 0;
 		for ( int sampleCount = animation->sampleCount; sampleCount > 1; sampleCount >>= 1 )
 		{
@@ -19626,9 +19639,10 @@ static void ksGltfScene_Simulate( ksGltfScene * scene, ksViewState * viewState, 
 
 			ksMatrix4x4f_Multiply( &viewState->viewMatrix[eye], &eyeOffsetMatrix, &viewState->centerViewMatrix );
 			ksMatrix4x4f_CreateProjectionFov( &viewState->projectionMatrix[eye],
-											cameraNode->camera->perspective.fovDegreesX,
-											cameraNode->camera->perspective.fovDegreesY,
-											0.0f, 0.0f,
+											cameraNode->camera->perspective.fovDegreesX * 0.5f,
+											cameraNode->camera->perspective.fovDegreesX * 0.5f,
+											cameraNode->camera->perspective.fovDegreesY * 0.5f,
+											cameraNode->camera->perspective.fovDegreesY * 0.5f,
 											cameraNode->camera->perspective.nearZ, cameraNode->camera->perspective.farZ );
 
 			ksViewState_DerivedData( viewState );
@@ -20029,9 +20043,9 @@ typedef struct
 	bool						hideGraphs;
 	ksTimeWarpImplementation	timeWarpImplementation;
 	ksRenderMode				renderMode;
-	ksMicroseconds				startupTimeMicroseconds;
-	ksMicroseconds				noVSyncMicroseconds;
-	ksMicroseconds				noLogMicroseconds;
+	ksNanoseconds				startupTimeNanoseconds;
+	ksNanoseconds				noVSyncNanoseconds;
+	ksNanoseconds				noLogNanoseconds;
 } ksStartupSettings;
 
 static int ksStartupSettings_StringToLevel( const char * string, const int maxLevels )
@@ -20150,7 +20164,7 @@ void SceneThread_Render( ksSceneThreadData * threadData )
 			ksFrameLog_Open( OUTPUT_PATH "framelog_scene.txt", 10 );
 		}
 
-		const ksMicroseconds nextDisplayTime = ksTimeWarp_GetPredictedDisplayTime( threadData->timeWarp, frameIndex );
+		const ksNanoseconds nextDisplayTime = ksTimeWarp_GetPredictedDisplayTime( threadData->timeWarp, frameIndex );
 
 #if USE_GLTF == 1
 		ksGltfScene_Simulate( &scene, &viewState, threadData->input, nextDisplayTime );
@@ -20160,7 +20174,7 @@ void SceneThread_Render( ksSceneThreadData * threadData )
 
 		ksFrameLog_BeginFrame();
 
-		const ksMicroseconds t0 = GetTimeMicroseconds();
+		const ksNanoseconds t0 = GetTimeNanoseconds();
 
 		if ( threadData->sceneSettings->useMultiView )
 		{
@@ -20226,15 +20240,15 @@ void SceneThread_Render( ksSceneThreadData * threadData )
 			eyeCompletionFence[eye] = ksGpuCommandBuffer_SubmitPrimary( &eyeCommandBuffer[eye] );
 		}
 
-		const ksMicroseconds t1 = GetTimeMicroseconds();
+		const ksNanoseconds t1 = GetTimeNanoseconds();
 
-		const float eyeTexturesCpuTime = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-		const float eyeTexturesGpuTime = ksGpuTimer_GetMilliseconds( &eyeTimer[0] ) + ksGpuTimer_GetMilliseconds( &eyeTimer[1] );
+		const ksNanoseconds eyeTexturesCpuTime = t1 - t0;
+		const ksNanoseconds eyeTexturesGpuTime = ksGpuTimer_GetNanoseconds( &eyeTimer[0] ) + ksGpuTimer_GetNanoseconds( &eyeTimer[1] );
 
 		ksFrameLog_EndFrame( eyeTexturesCpuTime, eyeTexturesGpuTime, GPU_TIMER_FRAMES_DELAYED );
 
 		ksMatrix4x4f projectionMatrix;
-		ksMatrix4x4f_CreateProjectionFov( &projectionMatrix, 80.0f, 80.0f, 0.0f, 0.0f, 0.1f, 0.0f );
+		ksMatrix4x4f_CreateProjectionFov( &projectionMatrix, 40.0f, 40.0f, 40.0f, 40.0f, DEFAULT_NEAR_Z, 0.0f );
 
 		ksTimeWarp_SubmitFrame( threadData->timeWarp, frameIndex, nextDisplayTime,
 								&viewState.hmdViewMatrix, &projectionMatrix,
@@ -20310,7 +20324,7 @@ bool RenderAsyncTimeWarp( ksStartupSettings * startupSettings )
 						WINDOW_RESOLUTION( displayResolutionTable[startupSettings->displayResolutionLevel * 2 + 1], startupSettings->fullscreen ),
 						startupSettings->fullscreen );
 
-	int swapInterval = ( startupSettings->noVSyncMicroseconds <= 0 );
+	int swapInterval = ( startupSettings->noVSyncNanoseconds <= 0 );
 	ksGpuWindow_SwapInterval( &window, swapInterval );
 
 	ksTimeWarp timeWarp;
@@ -20343,16 +20357,16 @@ bool RenderAsyncTimeWarp( ksStartupSettings * startupSettings )
 
 	hmd_headRotationDisabled = startupSettings->headRotationDisabled;
 
-	ksMicroseconds startupTimeMicroseconds = startupSettings->startupTimeMicroseconds;
-	ksMicroseconds noVSyncMicroseconds = startupSettings->noVSyncMicroseconds;
-	ksMicroseconds noLogMicroseconds = startupSettings->noLogMicroseconds;
+	ksNanoseconds startupTimeNanoseconds = startupSettings->startupTimeNanoseconds;
+	ksNanoseconds noVSyncNanoseconds = startupSettings->noVSyncNanoseconds;
+	ksNanoseconds noLogNanoseconds = startupSettings->noLogNanoseconds;
 
 	ksThread_SetName( "atw:timewarp" );
 
 	bool exit = false;
 	while ( !exit )
 	{
-		const ksMicroseconds time = GetTimeMicroseconds();
+		const ksNanoseconds time = GetTimeNanoseconds();
 
 		const ksGpuWindowEvent handleEvent = ksGpuWindow_ProcessEvents( &window );
 		if ( handleEvent == GPU_WINDOW_EVENT_ACTIVATED )
@@ -20380,18 +20394,18 @@ bool RenderAsyncTimeWarp( ksStartupSettings * startupSettings )
 			break;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_V ) ||
-			( noVSyncMicroseconds > 0 && time - startupTimeMicroseconds > noVSyncMicroseconds ) )
+			( noVSyncNanoseconds > 0 && time - startupTimeNanoseconds > noVSyncNanoseconds ) )
 		{
 			swapInterval = !swapInterval;
 			ksGpuWindow_SwapInterval( &window, swapInterval );
-			noVSyncMicroseconds = 0;
+			noVSyncNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_L ) ||
-			( noLogMicroseconds > 0 && time - startupTimeMicroseconds > noLogMicroseconds ) )
+			( noLogNanoseconds > 0 && time - startupTimeNanoseconds > noLogNanoseconds ) )
 		{
 			ksFrameLog_Open( OUTPUT_PATH "framelog_timewarp.txt", 10 );
 			sceneThreadData.openFrameLog = true;
-			noLogMicroseconds = 0;
+			noLogNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_H ) )
 		{
@@ -20500,7 +20514,7 @@ bool RenderTimeWarp( ksStartupSettings * startupSettings )
 						WINDOW_RESOLUTION( displayResolutionTable[startupSettings->displayResolutionLevel * 2 + 1], startupSettings->fullscreen ),
 						startupSettings->fullscreen );
 
-	int swapInterval = ( startupSettings->noVSyncMicroseconds <= 0 );
+	int swapInterval = ( startupSettings->noVSyncNanoseconds <= 0 );
 	ksGpuWindow_SwapInterval( &window, swapInterval );
 
 	ksTimeWarp timeWarp;
@@ -20512,16 +20526,16 @@ bool RenderTimeWarp( ksStartupSettings * startupSettings )
 
 	hmd_headRotationDisabled = startupSettings->headRotationDisabled;
 
-	ksMicroseconds startupTimeMicroseconds = startupSettings->startupTimeMicroseconds;
-	ksMicroseconds noVSyncMicroseconds = startupSettings->noVSyncMicroseconds;
-	ksMicroseconds noLogMicroseconds = startupSettings->noLogMicroseconds;
+	ksNanoseconds startupTimeNanoseconds = startupSettings->startupTimeNanoseconds;
+	ksNanoseconds noVSyncNanoseconds = startupSettings->noVSyncNanoseconds;
+	ksNanoseconds noLogNanoseconds = startupSettings->noLogNanoseconds;
 
 	ksThread_SetName( "atw:timewarp" );
 
 	bool exit = false;
 	while ( !exit )
 	{
-		const ksMicroseconds time = GetTimeMicroseconds();
+		const ksNanoseconds time = GetTimeNanoseconds();
 
 		const ksGpuWindowEvent handleEvent = ksGpuWindow_ProcessEvents( &window );
 		if ( handleEvent == GPU_WINDOW_EVENT_ACTIVATED )
@@ -20548,17 +20562,17 @@ bool RenderTimeWarp( ksStartupSettings * startupSettings )
 			break;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_V ) ||
-			( noVSyncMicroseconds > 0 && time - startupTimeMicroseconds > noVSyncMicroseconds ) )
+			( noVSyncNanoseconds > 0 && time - startupTimeNanoseconds > noVSyncNanoseconds ) )
 		{
 			swapInterval = !swapInterval;
 			ksGpuWindow_SwapInterval( &window, swapInterval );
-			noVSyncMicroseconds = 0;
+			noVSyncNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_L ) ||
-			( noLogMicroseconds > 0 && time - startupTimeMicroseconds > noLogMicroseconds ) )
+			( noLogNanoseconds > 0 && time - startupTimeNanoseconds > noLogNanoseconds ) )
 		{
 			ksFrameLog_Open( OUTPUT_PATH "framelog_timewarp.txt", 10 );
-			noLogMicroseconds = 0;
+			noLogNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_H ) )
 		{
@@ -20633,7 +20647,7 @@ bool RenderScene( ksStartupSettings * startupSettings )
 						WINDOW_RESOLUTION( displayResolutionTable[startupSettings->displayResolutionLevel * 2 + 1], startupSettings->fullscreen ),
 						startupSettings->fullscreen );
 
-	int swapInterval = ( startupSettings->noVSyncMicroseconds <= 0 );
+	int swapInterval = ( startupSettings->noVSyncNanoseconds <= 0 );
 	ksGpuWindow_SwapInterval( &window, swapInterval );
 
 	ksGpuRenderPass renderPass;
@@ -20680,16 +20694,16 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 	hmd_headRotationDisabled = startupSettings->headRotationDisabled;
 
-	ksMicroseconds startupTimeMicroseconds = startupSettings->startupTimeMicroseconds;
-	ksMicroseconds noVSyncMicroseconds = startupSettings->noVSyncMicroseconds;
-	ksMicroseconds noLogMicroseconds = startupSettings->noLogMicroseconds;
+	ksNanoseconds startupTimeNanoseconds = startupSettings->startupTimeNanoseconds;
+	ksNanoseconds noVSyncNanoseconds = startupSettings->noVSyncNanoseconds;
+	ksNanoseconds noLogNanoseconds = startupSettings->noLogNanoseconds;
 
 	ksThread_SetName( "atw:scene" );
 
 	bool exit = false;
 	while ( !exit )
 	{
-		const ksMicroseconds time = GetTimeMicroseconds();
+		const ksNanoseconds time = GetTimeNanoseconds();
 
 		const ksGpuWindowEvent handleEvent = ksGpuWindow_ProcessEvents( &window );
 		if ( handleEvent == GPU_WINDOW_EVENT_ACTIVATED )
@@ -20717,17 +20731,17 @@ bool RenderScene( ksStartupSettings * startupSettings )
 			break;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_V ) ||
-			( noVSyncMicroseconds > 0 && time - startupTimeMicroseconds > noVSyncMicroseconds ) )
+			( noVSyncNanoseconds > 0 && time - startupTimeNanoseconds > noVSyncNanoseconds ) )
 		{
 			swapInterval = !swapInterval;
 			ksGpuWindow_SwapInterval( &window, swapInterval );
-			noVSyncMicroseconds = 0;
+			noVSyncNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_L ) ||
-			( noLogMicroseconds > 0 && time - startupTimeMicroseconds > noLogMicroseconds ) )
+			( noLogNanoseconds > 0 && time - startupTimeNanoseconds > noLogNanoseconds ) )
 		{
 			ksFrameLog_Open( OUTPUT_PATH "framelog_scene.txt", 10 );
-			noLogMicroseconds = 0;
+			noLogNanoseconds = 0;
 		}
 		if ( ksGpuWindowInput_ConsumeKeyboardKey( &window.input, KEY_H ) )
 		{
@@ -20774,7 +20788,7 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 		if ( window.windowActive )
 		{
-			const ksMicroseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeMicroseconds( &window );
+			const ksNanoseconds nextSwapTime = ksGpuWindow_GetNextSwapTimeNanoseconds( &window );
 
 #if USE_GLTF == 1
 			ksGltfScene_Simulate( &scene, &viewState, &window.input, nextSwapTime );
@@ -20784,7 +20798,7 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 			ksFrameLog_BeginFrame();
 
-			const ksMicroseconds t0 = GetTimeMicroseconds();
+			const ksNanoseconds t0 = GetTimeNanoseconds();
 
 			const ksScreenRect screenRect = ksGpuFramebuffer_GetRect( &framebuffer );
 
@@ -20823,15 +20837,15 @@ bool RenderScene( ksStartupSettings * startupSettings )
 
 			ksGpuCommandBuffer_SubmitPrimary( &commandBuffer );
 
-			const ksMicroseconds t1 = GetTimeMicroseconds();
+			const ksNanoseconds t1 = GetTimeNanoseconds();
 
-			const float sceneCpuTimeMilliseconds = ( t1 - t0 ) * ( 1.0f / 1000.0f );
-			const float sceneGpuTimeMilliseconds = ksGpuTimer_GetMilliseconds( &timer );
+			const ksNanoseconds sceneCpuTime = t1 - t0;
+			const ksNanoseconds sceneGpuTime = ksGpuTimer_GetNanoseconds( &timer );
 
-			ksFrameLog_EndFrame( sceneCpuTimeMilliseconds, sceneGpuTimeMilliseconds, GPU_TIMER_FRAMES_DELAYED );
+			ksFrameLog_EndFrame( sceneCpuTime, sceneGpuTime, GPU_TIMER_FRAMES_DELAYED );
 
-			ksBarGraph_AddBar( &frameCpuTimeBarGraph, 0, sceneCpuTimeMilliseconds * window.windowRefreshRate * ( 1.0f / 1000.0f ), &colorGreen, true );
-			ksBarGraph_AddBar( &frameGpuTimeBarGraph, 0, sceneGpuTimeMilliseconds * window.windowRefreshRate * ( 1.0f / 1000.0f ), &colorGreen, true );
+			ksBarGraph_AddBar( &frameCpuTimeBarGraph, 0, sceneCpuTime * window.windowRefreshRate * 1e-9f, &colorGreen, true );
+			ksBarGraph_AddBar( &frameGpuTimeBarGraph, 0, sceneGpuTime * window.windowRefreshRate * 1e-9f, &colorGreen, true );
 
 			ksGpuWindow_SwapBuffers( &window );
 		}
@@ -20866,7 +20880,7 @@ static int StartApplication( int argc, char * argv[] )
 {
 	ksStartupSettings startupSettings;
 	memset( &startupSettings, 0, sizeof( startupSettings ) );
-	startupSettings.startupTimeMicroseconds = GetTimeMicroseconds();
+	startupSettings.startupTimeNanoseconds = GetTimeNanoseconds();
 	
 	for ( int i = 1; i < argc; i++ )
 	{
@@ -20874,7 +20888,7 @@ static int StartApplication( int argc, char * argv[] )
 		if ( arg[0] == '-' ) { arg++; }
 
 		if ( strcmp( arg, "f" ) == 0 && i + 0 < argc )		{ startupSettings.fullscreen = true; }
-		else if ( strcmp( arg, "v" ) == 0 && i + 1 < argc )	{ startupSettings.noVSyncMicroseconds = (ksMicroseconds)( atof( argv[++i] ) * 1000 * 1000 ); }
+		else if ( strcmp( arg, "v" ) == 0 && i + 1 < argc )	{ startupSettings.noVSyncNanoseconds = (ksNanoseconds)( atof( argv[++i] ) * 1000 * 1000 * 1000 ); }
 		else if ( strcmp( arg, "h" ) == 0 && i + 0 < argc )	{ startupSettings.headRotationDisabled = true; }
 		else if ( strcmp( arg, "p" ) == 0 && i + 0 < argc )	{ startupSettings.simulationPaused = true; }
 		else if ( strcmp( arg, "r" ) == 0 && i + 1 < argc )	{ startupSettings.displayResolutionLevel = ksStartupSettings_StringToLevel( argv[++i], MAX_DISPLAY_RESOLUTION_LEVELS ); }
@@ -20888,7 +20902,7 @@ static int StartApplication( int argc, char * argv[] )
 		else if ( strcmp( arg, "i" ) == 0 && i + 1 < argc )	{ startupSettings.timeWarpImplementation = (ksTimeWarpImplementation)ksStartupSettings_StringToTimeWarpImplementation( argv[++i] ); }
 		else if ( strcmp( arg, "z" ) == 0 && i + 1 < argc )	{ startupSettings.renderMode = ksStartupSettings_StringToRenderMode( argv[++i] ); }
 		else if ( strcmp( arg, "g" ) == 0 && i + 0 < argc )	{ startupSettings.hideGraphs = true; }
-		else if ( strcmp( arg, "l" ) == 0 && i + 1 < argc )	{ startupSettings.noLogMicroseconds = (ksMicroseconds)( atof( argv[++i] ) * 1000 * 1000 ); }
+		else if ( strcmp( arg, "l" ) == 0 && i + 1 < argc )	{ startupSettings.noLogNanoseconds = (ksNanoseconds)( atof( argv[++i] ) * 1000 * 1000 * 1000 ); }
 		else if ( strcmp( arg, "d" ) == 0 && i + 0 < argc )	{ DumpGLSL(); exit( 0 ); }
 		else
 		{
@@ -20926,7 +20940,7 @@ static int StartApplication( int argc, char * argv[] )
 	//startupSettings.timeWarpImplementation = TIMEWARP_IMPLEMENTATION_COMPUTE;
 
 	Print( "    fullscreen = %d\n",					startupSettings.fullscreen );
-	Print( "    noVSyncMicroseconds = %lld\n",		startupSettings.noVSyncMicroseconds );
+	Print( "    noVSyncNanoseconds = %lld\n",		startupSettings.noVSyncNanoseconds );
 	Print( "    headRotationDisabled = %d\n",		startupSettings.headRotationDisabled );
 	Print( "    simulationPaused = %d\n",			startupSettings.simulationPaused );
 	Print( "    displayResolutionLevel = %d\n",		startupSettings.displayResolutionLevel );
@@ -20940,7 +20954,7 @@ static int StartApplication( int argc, char * argv[] )
 	Print( "    timeWarpImplementation = %d\n",		startupSettings.timeWarpImplementation );
 	Print( "    renderMode = %d\n",					startupSettings.renderMode );
 	Print( "    hideGraphs = %d\n",					startupSettings.hideGraphs );
-	Print( "    noLogMicroseconds = %lld\n",		startupSettings.noLogMicroseconds );
+	Print( "    noLogNanoseconds = %lld\n",			startupSettings.noLogNanoseconds );
 
 	for ( bool exit = false; !exit; )
 	{

--- a/samples/apps/atw/atw_vulkan.c
+++ b/samples/apps/atw/atw_vulkan.c
@@ -3436,8 +3436,8 @@ static bool ksGpuDevice_Create( ksGpuDevice * device, ksDriverInstance * instanc
 		Print( "Device Name          : %s\n", physicalDeviceProperties.deviceName );
 		Print( "Device Type          : %s\n",	( ( physicalDeviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ) ? "integrated GPU" :
 					( ( physicalDeviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU ) ? "discrete GPU" :
-					  ( ( physicalDeviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU ) ? "virtual GPU" :
-						( ( physicalDeviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU ) ? "CPU" : "unknown" ) ) ) ) );
+					( ( physicalDeviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU ) ? "virtual GPU" :
+					( ( physicalDeviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU ) ? "CPU" : "unknown" ) ) ) ) );
 		Print( "Vendor ID            : 0x%04X\n", physicalDeviceProperties.vendorID );		// http://pcidatabase.com
 		Print( "Device ID            : 0x%04X\n", physicalDeviceProperties.deviceID );
 		Print( "Driver Version       : %d.%d.%d\n", driverMajor, driverMinor, driverPatch );

--- a/samples/apps/atw/projects/android/gradle/atw_cpu_dsp/build.bat
+++ b/samples/apps/atw/projects/android/gradle/atw_cpu_dsp/build.bat
@@ -3,7 +3,7 @@
 set BUILD_DIR="../../../../../../../build/android/gradle/apps/atw_cpu_dsp/"
 
 call gradlew --project-cache-dir %BUILD_DIR%.gradle build
-call adb push %BUILD_DIR%build/libs/armeabi-v7a/atw_cpu_dsp /data/local
+call adb push %BUILD_DIR%libs/armeabi-v7a/atw_cpu_dsp /data/local
 call adb shell chmod 777 /data/local/atw_cpu_dsp
 call adb shell mkdir -p /sdcard/atw/images/
 call adb shell rm /sdcard/atw/images/*

--- a/samples/apps/atw/projects/android/gradle/atw_cpu_dsp/build.sh
+++ b/samples/apps/atw/projects/android/gradle/atw_cpu_dsp/build.sh
@@ -3,7 +3,7 @@
 set BUILD_DIR="../../../../../../../build/android/gradle/apps/atw_cpu_dsp/"
 
 gradlew --project-cache-dir ${BUILD_DIR}.gradle build
-adb push ${BUILD_DIR}build/libs/armeabi-v7a/atw_cpu_dsp /data/local
+adb push ${BUILD_DIR}libs/armeabi-v7a/atw_cpu_dsp /data/local
 adb shell chmod 777 /data/local/atw_cpu_dsp
 adb shell mkdir -p /sdcard/atw/images/
 adb shell rm /sdcard/atw/images/*

--- a/samples/apps/atw/projects/android/gradle/atw_opengl/build.bat
+++ b/samples/apps/atw/projects/android/gradle/atw_opengl/build.bat
@@ -3,6 +3,6 @@
 set BUILD_DIR="../../../../../../../build/android/gradle/apps/atw_opengl/"
 
 call gradlew --project-cache-dir %BUILD_DIR%.gradle build
-call jar -tf %BUILD_DIR%build\outputs\apk\atw_opengl-all-debug.apk
-call adb install -r %BUILD_DIR%build/outputs/apk/atw_opengl-all-debug.apk
+call jar -tf %BUILD_DIR%outputs\apk\atw_opengl-all-debug.apk
+call adb install -r %BUILD_DIR%outputs/apk/atw_opengl-all-debug.apk
 call adb shell am start -n com.vulkansamples.atw_opengl/android.app.NativeActivity

--- a/samples/apps/atw/projects/android/gradle/atw_opengl/build.sh
+++ b/samples/apps/atw/projects/android/gradle/atw_opengl/build.sh
@@ -3,6 +3,6 @@
 set BUILD_DIR="../../../../../../../build/android/gradle/apps/atw_opengl/"
 
 gradlew --project-cache-dir ${BUILD_DIR}.gradle build
-jar -tf ${BUILD_DIR}build/outputs/apk/atw_opengl-all-debug.apk
-adb install -r ${BUILD_DIR}build/outputs/apk/atw_opengl-all-debug.apk
+jar -tf ${BUILD_DIR}outputs/apk/atw_opengl-all-debug.apk
+adb install -r ${BUILD_DIR}outputs/apk/atw_opengl-all-debug.apk
 adb shell am start -n com.vulkansamples.atw_opengl/android.app.NativeActivity

--- a/samples/apps/atw/projects/android/gradle/atw_vulkan/build.bat
+++ b/samples/apps/atw/projects/android/gradle/atw_vulkan/build.bat
@@ -4,11 +4,11 @@ set BUILD_DIR="../../../../../../../build/android/gradle/apps/atw_vulkan/"
 set MUXER_DIR="../../../../../../../build/android/gradle/layers/queue_muxer/"
 set GLSL_DIR="../../../../../../../build/android/gradle/layers/glsl_shader/"
 
-call xcopy /Y /S %MUXER_DIR%build\outputs\native\debug\all\lib\* %BUILD_DIR%build\intermediates\binaries\debug\all\lib\
-call xcopy /Y /S %MUXER_DIR%build\outputs\native\release\all\lib\* %BUILD_DIR%build\intermediates\binaries\release\all\lib\
-call xcopy /Y /S %GLSL_DIR%build\outputs\native\debug\all\lib\* %BUILD_DIR%build\intermediates\binaries\debug\all\lib\
-call xcopy /Y /S %GLSL_DIR%build\outputs\native\release\all\lib\* %BUILD_DIR%build\intermediates\binaries\release\all\lib\
+call xcopy /Y /S %MUXER_DIR%outputs\native\debug\all\lib\* %BUILD_DIR%intermediates\binaries\debug\all\lib\
+call xcopy /Y /S %MUXER_DIR%outputs\native\release\all\lib\* %BUILD_DIR%intermediates\binaries\release\all\lib\
+call xcopy /Y /S %GLSL_DIR%outputs\native\debug\all\lib\* %BUILD_DIR%intermediates\binaries\debug\all\lib\
+call xcopy /Y /S %GLSL_DIR%outputs\native\release\all\lib\* %BUILD_DIR%intermediates\binaries\release\all\lib\
 call gradlew --project-cache-dir %BUILD_DIR%.gradle build
-call jar -tf %BUILD_DIR%build\outputs\apk\atw_vulkan-all-debug.apk
-call adb install -r %BUILD_DIR%build/outputs/apk/atw_vulkan-all-debug.apk
+call jar -tf %BUILD_DIR%outputs\apk\atw_vulkan-all-debug.apk
+call adb install -r %BUILD_DIR%outputs/apk/atw_vulkan-all-debug.apk
 call adb shell am start -n com.vulkansamples.atw_vulkan/android.app.NativeActivity

--- a/samples/apps/atw/projects/android/gradle/atw_vulkan/build.sh
+++ b/samples/apps/atw/projects/android/gradle/atw_vulkan/build.sh
@@ -4,11 +4,11 @@ set BUILD_DIR="../../../../../../../build/android/gradle/apps/atw_vulkan/"
 set MUXER_DIR="../../../../../../../build/android/gradle/layers/queue_muxer/"
 set GLSL_DIR="../../../../../../../build/android/gradle/layers/glsl_shader/"
 
-cp /Y ${MUXER_DIR}build/outputs/native/debug/all/lib/* ${BUILD_DIR}build/intermediates/binaries/debug/all/lib/
-cp /Y ${MUXER_DIR}build/outputs/native/release/all/lib/* ${BUILD_DIR}build/intermediates/binaries/release/all/lib/
-cp /Y ${GLSL_DIR}build/outputs/native/debug/all/lib/* ${BUILD_DIR}build/intermediates/binaries/debug/all/lib/
-cp /Y ${GLSL_DIR}build/outputs/native/release/all/lib/* ${BUILD_DIR}build/intermediates/binaries/release/all/lib/
+cp /Y ${MUXER_DIR}outputs/native/debug/all/lib/* ${BUILD_DIR}intermediates/binaries/debug/all/lib/
+cp /Y ${MUXER_DIR}outputs/native/release/all/lib/* ${BUILD_DIR}intermediates/binaries/release/all/lib/
+cp /Y ${GLSL_DIR}outputs/native/debug/all/lib/* ${BUILD_DIR}intermediates/binaries/debug/all/lib/
+cp /Y ${GLSL_DIR}outputs/native/release/all/lib/* ${BUILD_DIR}intermediates/binaries/release/all/lib/
 gradlew --project-cache-dir ${BUILD_DIR}.gradle build
-jar -tf ${BUILD_DIR}build/outputs/apk/atw_vulkan-all-debug.apk
-adb install -r ${BUILD_DIR}build/outputs/apk/atw_vulkan-all-debug.apk
+jar -tf ${BUILD_DIR}outputs/apk/atw_vulkan-all-debug.apk
+adb install -r ${BUILD_DIR}outputs/apk/atw_vulkan-all-debug.apk
 adb shell am start -n com.vulkansamples.atw_vulkan/android.app.NativeActivity

--- a/samples/apps/atw/projects/android/ndk/atw_cpu_dsp/build.sh
+++ b/samples/apps/atw/projects/android/ndk/atw_cpu_dsp/build.sh
@@ -3,7 +3,7 @@
 set BUILD_DIR="../../../../../../../build/android/ndk/apps/atw_cpu_dsp/"
 
 ndk-build NDK_LIBS_OUT=${BUILD_DIR}libs NDK_OUT=${BUILD_DIR}obj
-adb push ${BUILD_DIR}build/libs/armeabi-v7a/atw_cpu_dsp /data/local
+adb push ${BUILD_DIR}libs/armeabi-v7a/atw_cpu_dsp /data/local
 adb shell chmod 777 /data/local/atw_cpu_dsp
 adb shell mkdir -p /sdcard/atw/images/
 adb shell rm /sdcard/atw/images/*

--- a/samples/layers/glsl_shader/projects/android/gradle/build.gradle
+++ b/samples/layers/glsl_shader/projects/android/gradle/build.gradle
@@ -51,7 +51,7 @@ model {
 		cppFlags.addAll([
 			"-I${file("${baseDir}/external/include")}".toString(),
 			"-I${file("${baseDir}/../Vulkan-LoaderAndValidationLayers/include")}".toString(),
-			"-I${file("${baseDir}/../Vulkan-LoaderAndValidationLayers/build/layers")}".toString(),
+			"-I${file("${baseDir}/../Vulkan-LoaderAndValidationLayers/build/generated/include")}".toString(),
 			"-I${file("${baseDir}/../glslang")}".toString(),
 			"-I${file("${vkSdkPath}/Include")}".toString(),
 			"-I${file("${vkSdkPath}/Source/layers")}".toString()

--- a/samples/layers/glsl_shader/projects/android/ndk/jni/Android.mk
+++ b/samples/layers/glsl_shader/projects/android/ndk/jni/Android.mk
@@ -11,7 +11,7 @@ LOCAL_MODULE			:= VkLayer_glsl_shader
 LOCAL_C_INCLUDES		:= \
 							$(BASE_DIR)/Vulkan-Samples/external/include \
 							$(BASE_DIR)/Vulkan-LoaderAndValidationLayers/include \
-							$(BASE_DIR)/Vulkan-LoaderAndValidationLayers/build/layers \
+							$(BASE_DIR)/Vulkan-LoaderAndValidationLayers/build/generated/include \
 							$(BASE_DIR)/glslang \
 							$(VK_SDK_PATH)/Include \
 							$(VK_SDK_PATH)/Source/layers

--- a/samples/layers/queue_muxer/projects/android/gradle/build.gradle
+++ b/samples/layers/queue_muxer/projects/android/gradle/build.gradle
@@ -49,7 +49,7 @@ model {
 		CFlags.addAll([
 			"-I${file("${baseDir}/external/include")}".toString(),
 			"-I${file("${baseDir}/../Vulkan-LoaderAndValidationLayers/include")}".toString(),
-			"-I${file("${baseDir}/../Vulkan-LoaderAndValidationLayers/build/layers")}".toString(),
+			"-I${file("${baseDir}/../Vulkan-LoaderAndValidationLayers/build/generated/include")}".toString(),
 			"-I${file("${vkSdkPath}/Include")}".toString(),
 			"-I${file("${vkSdkPath}/Source/layers")}".toString()
 		])

--- a/samples/layers/queue_muxer/projects/android/ndk/jni/Android.mk
+++ b/samples/layers/queue_muxer/projects/android/ndk/jni/Android.mk
@@ -8,7 +8,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_queue_muxer
 LOCAL_C_INCLUDES := $(BASE_DIR)/Vulkan-Samples/external/include \
                     $(BASE_DIR)/Vulkan-LoaderAndValidationLayers/include \
-                    $(BASE_DIR)/Vulkan-LoaderAndValidationLayers/build/layers \
+                    $(BASE_DIR)/Vulkan-LoaderAndValidationLayers/build/generated/include \
                     $(VK_SDK_PATH)/Include \
                     $(VK_SDK_PATH)/Source/layers
 LOCAL_SRC_FILES  := $(BASE_DIR)/samples/layers/queue_muxer/queue_muxer.c


### PR DESCRIPTION
Changed ATW samples to use nanoseconds instead of microseconds. Fixed previous JSON object/array member pointers going stale when new members are added. Fixed Vulkan-LoadAndValidation dependency.